### PR TITLE
Use opaque pointer in C

### DIFF
--- a/src/genny/languages/c.nim
+++ b/src/genny/languages/c.nim
@@ -152,7 +152,7 @@ proc exportObjectC*(sym: NimNode, constructor: NimNode) =
   dllProc(&"$lib_{toSnakeCase(objName)}_eq", [&"{objName} a", &"{objName} b"], "char")
 
 proc genRefObject(objName: string) =
-  types.add &"typedef long long {objName};\n\n"
+  types.add &"typedef struct _{objName}* {objName};\n\n"
 
   let unrefLibProc = &"$lib_{toSnakeCase(objName)}_unref"
 


### PR DESCRIPTION
Example code
```c
// typedef struct Image* Image;
// ^ This works fine, but my auto-completion complaining for some reason.
// So i have to prepend with '_'


typedef struct _Image* Image;
```
there won't be a lot of changes like Zig opaque pointer
Opaque type behaves as same as `pointer` in Nim