### PR TITLE
[codex] Add CPython native Python backend

### DIFF
--- a/.github/workflows/python-native.yml
+++ b/.github/workflows/python-native.yml
@@ -1,0 +1,24 @@
+name: Python Native
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: treeform/setup-nim-action@v6
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Build native extension
+      run: |
+        EXT_SUFFIX="$(python -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')"
+        nim c --mm:arc --app:lib -d:gennyPythonNative -o:tests/generated/test${EXT_SUFFIX} tests/test.nim
+    - name: Run native Python test
+      run: python tests/test_python_native.py
+    - name: Run non-gating benchmark
+      continue-on-error: true
+      run: python tests/bench_python_native.py

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,3 +17,6 @@ jobs:
       run: nim c --mm:arc --app:lib -d:gennyPython -o:tests/generated/libtest.so tests/test.nim
     - name: Run Python test
       run: python tests/test_python.py
+    - name: Run non-gating benchmark
+      continue-on-error: true
+      run: python tests/bench_python.py

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,13 @@
 *.exe
 *.dll
 *.so
+*.pyd
+*.deps
 nimcache
+__pycache__/
+tests/generated/*_native.c
 *.pdb
 *.ilk
 .*
+!.github/
+!.github/**

--- a/src/genny.nim
+++ b/src/genny.nim
@@ -1,9 +1,15 @@
-import genny/internal, genny/languages/c, genny/languages/cpp,
-    genny/languages/nim, genny/languages/node, genny/languages/python,
-    genny/languages/zig, macros, strformat
+import genny/internal, macros, strformat
 
-when not defined(gennyNim) and not defined(gennyPython) and not defined(gennyNode) and not defined(gennyC) and not defined(gennyCpp) and not defined(gennyZig):
-  {.error: "Please define one of the genny languages. Use -d:gennyNim, -d:gennyPython, -d:gennyNode, -d:gennyC, -d:gennyCpp, -d:gennyZig to define the languages you want to export.".}
+when defined(gennyC): import genny/languages/c
+when defined(gennyCpp): import genny/languages/cpp
+when defined(gennyNim): import genny/languages/nim
+when defined(gennyNode): import genny/languages/node
+when defined(gennyPython): import genny/languages/python
+when defined(gennyPythonNative): import genny/languages/python_native
+when defined(gennyZig): import genny/languages/zig
+
+when not defined(gennyNim) and not defined(gennyPython) and not defined(gennyPythonNative) and not defined(gennyNode) and not defined(gennyC) and not defined(gennyCpp) and not defined(gennyZig):
+  {.error: "Please define one of the genny languages. Use -d:gennyNim, -d:gennyPython, -d:gennyPythonNative, -d:gennyNode, -d:gennyC, -d:gennyCpp, -d:gennyZig to define the languages you want to export.".}
 
 template discard2(f: untyped): untyped =
   when(compiles do: discard f):
@@ -38,6 +44,7 @@ macro exportConstsTyped(body: typed) =
     exportConstInternal(sym)
     when defined(gennyNim): exportConstNim(sym)
     when defined(gennyPython): exportConstPy(sym)
+    when defined(gennyPythonNative): exportConstPyNative(sym)
     when defined(gennyNode): exportConstNode(sym)
     when defined(gennyC): exportConstC(sym)
     when defined(gennyCpp): exportConstCpp(sym)
@@ -62,6 +69,7 @@ macro exportEnumsTyped(body: typed) =
     exportEnumInternal(sym)
     when defined(gennyNim): exportEnumNim(sym)
     when defined(gennyPython): exportEnumPy(sym)
+    when defined(gennyPythonNative): exportEnumPyNative(sym)
     when defined(gennyNode): exportEnumNode(sym)
     when defined(gennyC): exportEnumC(sym)
     when defined(gennyCpp): exportEnumCpp(sym)
@@ -120,6 +128,7 @@ proc procTyped(
   exportProcInternal(procSym, owner, prefixes)
   when defined(gennyNim): exportProcNim(procSym, owner, prefixes)
   when defined(gennyPython): exportProcPy(procSym, owner, prefixes)
+  when defined(gennyPythonNative): exportProcPyNative(procSym, owner, prefixes)
   when defined(gennyNode): exportProcNode(procSym, owner, prefixes)
   when defined(gennyC): exportProcC(procSym, owner, prefixes)
   when defined(gennyCpp): exportProcCpp(procSym, owner, prefixes)
@@ -179,12 +188,13 @@ macro exportObjectTyped(body: typed) =
       nil
 
   exportObjectInternal(sym, constructor)
-  exportObjectNim(sym, constructor)
-  exportObjectPy(sym, constructor)
-  exportObjectNode(sym, constructor)
-  exportObjectC(sym, constructor)
-  exportObjectCpp(sym, constructor)
-  exportObjectZig(sym, constructor)
+  when defined(gennyNim): exportObjectNim(sym, constructor)
+  when defined(gennyPython): exportObjectPy(sym, constructor)
+  when defined(gennyPythonNative): exportObjectPyNative(sym, constructor)
+  when defined(gennyNode): exportObjectNode(sym, constructor)
+  when defined(gennyC): exportObjectC(sym, constructor)
+  when defined(gennyCpp): exportObjectCpp(sym, constructor)
+  when defined(gennyZig): exportObjectZig(sym, constructor)
 
   if procsBlock[1].len > 0:
     var procsSeen: seq[string]
@@ -201,13 +211,14 @@ macro exportObjectTyped(body: typed) =
       exportProcInternal(procSym, sym, prefixes)
       when defined(gennyNim): exportProcNim(procSym, sym, prefixes)
       when defined(gennyPython): exportProcPy(procSym, sym, prefixes)
+      when defined(gennyPythonNative): exportProcPyNative(procSym, sym, prefixes)
       when defined(gennyNode): exportProcNode(procSym, sym, prefixes)
       when defined(gennyC): exportProcC(procSym, sym, prefixes)
       when defined(gennyCpp): exportProcCpp(procSym, sym, prefixes)
       when defined(gennyZig): exportProcZig(procSym, sym, prefixes)
 
-  exportCloseObjectZig()
-  exportCloseObjectCpp()
+  when defined(gennyZig): exportCloseObjectZig()
+  when defined(gennyCpp): exportCloseObjectCpp()
 
 template exportObject*(sym, body: untyped) =
   ## Exports an object, with these sections:
@@ -240,6 +251,7 @@ macro exportSeqTyped(body: typed) =
   exportSeqInternal(sym)
   when defined(gennyNim): exportSeqNim(sym)
   when defined(gennyPython): exportSeqPy(sym)
+  when defined(gennyPythonNative): exportSeqPyNative(sym)
   when defined(gennyNode): exportSeqNode(sym)
   when defined(gennyC): exportSeqC(sym)
   when defined(gennyCpp): exportSeqCpp(sym)
@@ -248,8 +260,8 @@ macro exportSeqTyped(body: typed) =
   for entry in body.asStmtList()[1 .. ^1]:
     procTyped(entry, sym)
 
-  exportCloseObjectCpp()
-  exportCloseObjectZig()
+  when defined(gennyCpp): exportCloseObjectCpp()
+  when defined(gennyZig): exportCloseObjectZig()
 
 template exportSeq*(sym, body: untyped) =
   ## Exports a regular sequence.
@@ -317,12 +329,13 @@ macro exportRefObjectTyped(body: typed) =
       nil
 
   exportRefObjectInternal(sym, fields, constructor)
-  exportRefObjectNim(sym, fields, constructor)
-  exportRefObjectPy(sym, fields, constructor)
-  exportRefObjectNode(sym, fields, constructor)
-  exportRefObjectC(sym, fields, constructor)
-  exportRefObjectCpp(sym, fields, constructor)
-  exportRefObjectZig(sym, fields, constructor)
+  when defined(gennyNim): exportRefObjectNim(sym, fields, constructor)
+  when defined(gennyPython): exportRefObjectPy(sym, fields, constructor)
+  when defined(gennyPythonNative): exportRefObjectPyNative(sym, fields, constructor)
+  when defined(gennyNode): exportRefObjectNode(sym, fields, constructor)
+  when defined(gennyC): exportRefObjectC(sym, fields, constructor)
+  when defined(gennyCpp): exportRefObjectCpp(sym, fields, constructor)
+  when defined(gennyZig): exportRefObjectZig(sym, fields, constructor)
 
   if procsBlock[1].len > 0:
     var procsSeen: seq[string]
@@ -339,13 +352,14 @@ macro exportRefObjectTyped(body: typed) =
       exportProcInternal(procSym, sym, prefixes)
       when defined(gennyNim): exportProcNim(procSym, sym, prefixes)
       when defined(gennyPython): exportProcPy(procSym, sym, prefixes)
+      when defined(gennyPythonNative): exportProcPyNative(procSym, sym, prefixes)
       when defined(gennyNode): exportProcNode(procSym, sym, prefixes)
       when defined(gennyC): exportProcC(procSym, sym, prefixes)
       when defined(gennyCpp): exportProcCpp(procSym, sym, prefixes)
       when defined(gennyZig): exportProcZig(procSym, sym, prefixes)
 
-  exportCloseObjectCpp()
-  exportCloseObjectZig()
+  when defined(gennyCpp): exportCloseObjectCpp()
+  when defined(gennyZig): exportCloseObjectZig()
 
 template exportRefObject*(sym, body: untyped) =
   ## Exports a ref object, with these sections:
@@ -357,9 +371,11 @@ template exportRefObject*(sym, body: untyped) =
 macro writeFiles*(dir, lib: static[string]) =
   ## This needs to be and the end of the file and it needs to be followed by:
   ## `include generated/internal`
+  result = newStmtList()
   writeInternal(dir, lib)
   when defined(gennyNim): writeNim(dir, lib)
   when defined(gennyPython): writePy(dir, lib)
+  when defined(gennyPythonNative): result.add writePyNative(dir, lib)
   when defined(gennyNode): writeNode(dir, lib)
   when defined(gennyC): writeC(dir, lib)
   when defined(gennyCpp): writeCpp(dir, lib)

--- a/src/genny/languages/nim.nim
+++ b/src/genny/languages/nim.nim
@@ -7,68 +7,99 @@ var
   procs {.compiletime.}: string
   refObjectNames {.compiletime.}: HashSet[string]
 
+proc isSeqLike(sym: NimNode): bool =
+  ## Returns true for sequence-shaped types that Genny should expose through
+  ## generated seq wrappers. `openArray[T]` is normalized to the same wrapper
+  ## shape as `seq[T]` because exported bindings pass it through the internal
+  ## Nim ABI as an owned/generated sequence handle.
+  sym.kind == nnkBracketExpr and sym[0].repr in ["seq", "openArray"]
+
+proc stripSink(sym: NimNode): NimNode =
+  ## Removes Nim's `sink[T]` ownership wrapper so backend type generation can
+  ## reason about the payload type. The binding ABI does not expose `sink`
+  ## itself; it only needs to know that a `T` value is crossing the boundary.
+  if sym.kind == nnkBracketExpr and sym[0].repr == "sink":
+    return sym[1]
+  else:
+    return sym
+
 proc exportTypeNim*(sym: NimNode): string =
   ## Returns type for Nim wrapper proc signature.
-  if sym.kind == nnkBracketExpr:
-    if sym[0].repr != "seq":
-      error(&"Unexpected bracket expression {sym[0].repr}[", sym)
-    result = sym.getSeqName()
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if not typ.isSeqLike:
+      error(&"Unexpected bracket expression {typ[0].repr}[", typ)
+    return typ.getSeqName()
   else:
-    if sym.repr == "string":
-      result = "cstring"
-    elif sym.repr == "Rune":
-      result = "int32"
+    if typ.repr == "string":
+      return "cstring"
+    elif typ.repr == "Rune":
+      return "int32"
     else:
-      result = sym.repr
+      return typ.repr
 
 proc exportTypeCImport*(sym: NimNode): string =
   ## Returns type for C import declaration. Ref objects become pointer.
-  if sym.kind == nnkBracketExpr:
-    if sym[0].repr != "seq":
-      error(&"Unexpected bracket expression {sym[0].repr}[", sym)
-    result = "pointer"  # Sequences are ref objects
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if not typ.isSeqLike:
+      error(&"Unexpected bracket expression {typ[0].repr}[", typ)
+    return "pointer"  # Sequences are ref objects
   else:
-    if sym.repr == "string":
-      result = "cstring"
-    elif sym.repr == "Rune":
-      result = "int32"
-    elif sym.repr in refObjectNames:
-      result = "pointer"
+    if typ.repr == "string":
+      return "cstring"
+    elif typ.repr == "Rune":
+      return "int32"
+    elif typ.repr in refObjectNames:
+      return "pointer"
     else:
-      result = sym.repr
+      return typ.repr
 
 proc convertExportFromNim*(sym: NimNode): string =
   ## Converts Nim value to C value (used by DLL side).
-  if sym.kind == nnkBracketExpr:
-    discard
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if not typ.isSeqLike:
+      error(&"Unexpected bracket expression {typ[0].repr}[", typ)
+    return ""
   else:
-    if sym.repr == "string":
-      result = ".cstring"
-    elif sym.repr == "Rune":
-      result = ".int32"
+    if typ.repr == "string":
+      return ".cstring"
+    elif typ.repr == "Rune":
+      return ".int32"
+    else:
+      return ""
 
 proc convertToPointer*(sym: NimNode): string =
   ## Converts client-side wrapper to pointer for C call.
-  if sym.kind == nnkBracketExpr:
-    result = ".reference"  # Pass the pointer from ref wrapper
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if not typ.isSeqLike:
+      error(&"Unexpected bracket expression {typ[0].repr}[", typ)
+    return ".reference"  # Pass the pointer from ref wrapper
   else:
-    if sym.repr == "string":
-      result = ".cstring"
-    elif sym.repr == "Rune":
-      result = ".int32"
-    elif sym.repr in refObjectNames:
-      result = ".reference"
+    if typ.repr == "string":
+      return ".cstring"
+    elif typ.repr == "Rune":
+      return ".int32"
+    elif typ.repr in refObjectNames:
+      return ".reference"
+    else:
+      return ""
 
 proc convertImportToNim*(sym: NimNode): string =
-  if sym.kind == nnkBracketExpr:
-    if sym[0].repr != "seq":
-      error(&"Unexpected bracket expression {sym[0].repr}[", sym)
-    result = ".s"
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if not typ.isSeqLike:
+      error(&"Unexpected bracket expression {typ[0].repr}[", typ)
+    return ".s"
   else:
-    if sym.repr == "string":
-      result = ".`$`"
-    elif sym.repr == "Rune":
-      result = ".Rune"
+    if typ.repr == "string":
+      return ".`$`"
+    elif typ.repr == "Rune":
+      return ".Rune"
+    else:
+      return ""
 
 proc exportConstNim*(sym: NimNode) =
   let impl = sym.getImpl()

--- a/src/genny/languages/python.nim
+++ b/src/genny/languages/python.nim
@@ -8,20 +8,37 @@ var
 
 const operators = ["add", "sub", "mul", "div"]
 
+proc stripSink(sym: NimNode): NimNode =
+  ## Removes Nim's `sink[T]` ownership wrapper before mapping a type to ctypes.
+  ## Python callers pass the payload value; the generated Nim side handles the
+  ## ownership semantics at the ABI boundary.
+  if sym.kind == nnkBracketExpr and sym[0].repr == "sink":
+    sym[1]
+  else:
+    sym
+
+proc isSeqLike(sym: NimNode): bool =
+  ## Returns true for sequence-shaped types that should reuse Genny's generated
+  ## seq wrapper classes. `openArray[T]` is treated like `seq[T]` for Python
+  ## bindings because the internal ABI receives a generated sequence handle.
+  let typ = sym.stripSink
+  typ.kind == nnkBracketExpr and typ[0].repr in ["seq", "openArray"]
+
 proc exportTypePy(sym: NimNode): string =
-  if sym.kind == nnkBracketExpr:
-    if sym[0].repr == "array":
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if typ[0].repr == "array":
       let
-        entryCount = sym[1].repr
-        entryType = exportTypePy(sym[2])
+        entryCount = typ[1].repr
+        entryType = exportTypePy(typ[2])
       result = &"{entryType} * {entryCount}"
-    elif sym[0].repr == "seq":
-      result = sym.getSeqName()
+    elif typ.isSeqLike:
+      result = typ.getSeqName()
     else:
-      error(&"Unexpected bracket expression {sym[0].repr}[")
+      error(&"Unexpected bracket expression {typ[0].repr}[")
   else:
     result =
-      case sym.repr:
+      case typ.repr:
       of "string": "c_char_p"
       of "cstring": "c_char_p"
       of "pointer": "c_void_p"
@@ -45,14 +62,16 @@ proc exportTypePy(sym: NimNode): string =
       of "Mat3": "Matrix3"
       of "", "nil": "None"
       else:
-        sym.repr
+        typ.repr
 
 proc convertExportFromPy*(sym: NimNode): string =
-  if sym.repr == "string":
+  let typ = sym.stripSink
+  if typ.repr == "string":
     result = ".encode(\"utf8\")"
 
 proc convertImportToPy*(sym: NimNode): string =
-  if sym.repr == "string":
+  let typ = sym.stripSink
+  if typ.repr == "string":
     result = ".decode(\"utf8\")"
 
 proc toArgTypes(args: openarray[NimNode]): seq[string] =

--- a/src/genny/languages/python_native.nim
+++ b/src/genny/languages/python_native.nim
@@ -1,0 +1,1051 @@
+import
+  std/[compilesettings, macros, os, sets, strformat, strutils, tables],
+  ../common
+
+type
+  FieldInfo = tuple[name: string, typ: NimNode]
+
+var
+  cTypes {.compiletime.}: string
+  cProtos {.compiletime.}: string
+  cTypeBlocks {.compiletime.}: string
+  cWrappers {.compiletime.}: string
+  cModuleMethods {.compiletime.}: string
+  cModuleInit {.compiletime.}: string
+  cForwardDecls {.compiletime.}: string
+  valueObjectNames {.compiletime.}: HashSet[string]
+  refObjectNames {.compiletime.}: HashSet[string]
+  seqObjectNames {.compiletime.}: HashSet[string]
+  valueObjectFields {.compiletime.}: Table[string, seq[FieldInfo]]
+  valueObjectConstructors {.compiletime.}: Table[string, string]
+  seqEntryTypes {.compiletime.}: Table[string, NimNode]
+  seqNewProcs {.compiletime.}: Table[string, string]
+  typeMethods {.compiletime.}: Table[string, string]
+  enumTypeNames {.compiletime.}: HashSet[string]
+  needsErrorBridge {.compiletime.}: bool
+
+proc cString(s: string): string =
+  result = "\""
+  for ch in s:
+    case ch
+    of '\\': result.add "\\\\"
+    of '"': result.add "\\\""
+    of '\n': result.add "\\n"
+    of '\r': discard
+    else: result.add ch
+  result.add "\""
+
+proc cIdent(s: string): string =
+  for ch in s:
+    if ch in {'a'..'z', 'A'..'Z', '0'..'9', '_'}:
+      result.add ch
+    else:
+      result.add '_'
+
+proc stripSink(sym: NimNode): NimNode =
+  ## Removes Nim's `sink[T]` ownership wrapper before emitting C/CPython type
+  ## declarations. The native extension deals in payload types; Nim keeps the
+  ## move/ownership semantics on the generated wrapper side.
+  if sym.kind == nnkBracketExpr and sym[0].repr == "sink":
+    sym[1]
+  else:
+    sym
+
+proc nativeName(sym: NimNode): string =
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    typ.getSeqName()
+  else:
+    case typ.repr
+    of "Vec2": "Vector2"
+    of "Mat3": "Matrix3"
+    else: typ.repr
+
+proc typeObjName(name: string): string =
+  "GennyPy_" & cIdent(name) & "_Type"
+
+proc pyStructName(name: string): string =
+  "GennyPy_" & cIdent(name)
+
+proc isVoid(sym: NimNode): bool =
+  let typ = sym.stripSink
+  typ.kind == nnkEmpty or typ.repr in ["", "nil", "None"]
+
+proc isSeqType(sym: NimNode): bool =
+  let typ = sym.stripSink
+  typ.kind == nnkBracketExpr and typ[0].repr in ["seq", "openArray"]
+
+proc isArrayType(sym: NimNode): bool =
+  let typ = sym.stripSink
+  typ.kind == nnkBracketExpr and typ[0].repr == "array"
+
+proc isRefLikeObjectType(sym: NimNode): bool
+proc cBaseType(sym: NimNode): string
+
+proc cArraySuffix(sym: NimNode): string =
+  let typ = sym.stripSink
+  if typ.isArrayType:
+    result.add &"[{typ[1].repr}]"
+    result.add cArraySuffix(typ[2])
+
+proc cBaseType(sym: NimNode): string =
+  let typ = sym.stripSink
+  if typ.isArrayType:
+    return cBaseType(typ[2])
+  if typ.isSeqType:
+    return "void *"
+
+  let name = typ.nativeName()
+  if name in enumTypeNames:
+    return "int"
+  if typ.isRefLikeObjectType:
+    return "void *"
+
+  case name
+  of "string", "cstring": "char *"
+  of "bool": "char"
+  of "byte", "uint8": "unsigned char"
+  of "int8": "signed char"
+  of "int16": "short"
+  of "uint16": "unsigned short"
+  of "int32", "Rune": "int"
+  of "uint32": "unsigned int"
+  of "int64", "int": "long long"
+  of "uint64", "uint": "unsigned long long"
+  of "float32": "float"
+  of "float64", "float": "double"
+  of "", "nil", "None": "void"
+  else: name
+
+proc cType(sym: NimNode): string =
+  if sym.isArrayType:
+    error("array types need a declarator name", sym)
+  cBaseType(sym)
+
+proc cDecl(sym: NimNode, name: string): string =
+  let typ = sym.stripSink
+  if typ.isArrayType:
+    cBaseType(typ) & " " & name & cArraySuffix(typ)
+  else:
+    cType(typ) & " " & name
+
+proc pyTypeName(sym: NimNode): string =
+  sym.nativeName()
+
+proc isValueObjectType(sym: NimNode): bool =
+  sym.pyTypeName() in valueObjectNames
+
+proc isRefObjectType(sym: NimNode): bool =
+  sym.pyTypeName() in refObjectNames
+
+proc isNativeSeqObjectType(sym: NimNode): bool =
+  sym.pyTypeName() in seqObjectNames
+
+proc isForwardRefObjectType(sym: NimNode): bool =
+  let name = sym.pyTypeName()
+  name.len > 0 and name[0] in {'A'..'Z'} and
+    name notin ["Rune"] and
+    name notin valueObjectNames and name notin enumTypeNames
+
+proc isRefLikeObjectType(sym: NimNode): bool =
+  sym.isRefObjectType or sym.isNativeSeqObjectType or sym.isForwardRefObjectType
+
+proc apiProcName(sym: NimNode, owner: NimNode = nil, prefixes: openarray[NimNode] = []): string =
+  result = "$lib_"
+  if owner != nil:
+    result.add &"{toSnakeCase(owner.getName())}_"
+  for prefix in prefixes:
+    result.add &"{toSnakeCase(prefix.getName())}_"
+  result.add toSnakeCase(sym.repr)
+
+proc pyProcName(sym: NimNode, owner: NimNode = nil, prefixes: openarray[NimNode] = []): string =
+  if owner != nil:
+    for prefix in prefixes:
+      if prefix.getImpl().kind != nnkNilLit:
+        if prefix.getImpl()[2].kind != nnkEnumTy:
+          result.add &"{toSnakeCase(prefix.repr)}_"
+  result.add toSnakeCase(sym.repr)
+
+proc getDefaults(sym: NimNode): seq[NimNode] =
+  let procType = sym.getTypeInst()
+  let procParams = procType[0][1 .. ^1]
+  for param in procParams:
+    for _ in 0 .. param.len - 3:
+      result.add newEmptyNode()
+
+  var defaults: seq[(string, NimNode)]
+  for identDefs in sym.getImpl()[3][1 .. ^1]:
+    let default = identDefs[^1]
+    for entry in identDefs[0 .. ^3]:
+      defaults.add((entry.repr, default))
+
+  for i in 0 ..< min(result.len, defaults.len):
+    result[i] = defaults[i][1]
+
+proc defaultIsSimple(default: NimNode): bool =
+  if default.kind == nnkEmpty:
+    return false
+  case default.kind
+  of nnkIntLit, nnkUIntLit, nnkFloatLit, nnkFloat32Lit, nnkFloat64Lit:
+    true
+  of nnkIdent:
+    true
+  else:
+    false
+
+proc cDefaultLiteral(default: NimNode): string =
+  case default.kind
+  of nnkIdent:
+    case default.repr
+    of "true": "1"
+    of "false": "0"
+    else: toCapSnakeCase(default.repr)
+  else:
+    default.repr
+
+proc pyFromC(expr: string, typ: NimNode): string =
+  let baseTyp = typ.stripSink
+  let name = baseTyp.pyTypeName()
+  if baseTyp.isVoid:
+    return "Py_RETURN_NONE"
+  if baseTyp.isValueObjectType:
+    return &"GennyPy_{cIdent(name)}_FromValue({expr})"
+  if baseTyp.isRefLikeObjectType:
+    return &"GennyPy_{cIdent(name)}_FromRef((void *)({expr}))"
+  if baseTyp.isSeqType:
+    let seqName = baseTyp.getSeqName()
+    return &"GennyPy_{cIdent(seqName)}_FromRef((void *)({expr}))"
+
+  case baseTyp.nativeName()
+  of "string", "cstring":
+    &"PyUnicode_FromString(({expr}) ? ({expr}) : \"\")"
+  of "bool":
+    &"PyBool_FromLong((long)({expr}))"
+  of "byte", "uint8", "uint16", "uint32", "uint64", "uint":
+    &"PyLong_FromUnsignedLongLong((unsigned long long)({expr}))"
+  of "int8", "int16", "int32", "int64", "int", "Rune":
+    &"PyLong_FromLongLong((long long)({expr}))"
+  of "float32", "float64", "float":
+    &"PyFloat_FromDouble((double)({expr}))"
+  else:
+    &"PyLong_FromLongLong((long long)({expr}))"
+
+proc convertPyToC(pyExpr, outExpr: string, typ: NimNode, label: string): string =
+  let baseTyp = typ.stripSink
+  let name = baseTyp.pyTypeName()
+  if baseTyp.isValueObjectType:
+    return &"  if (!GennyPy_{cIdent(name)}_AsValue({pyExpr}, &{outExpr}, {cString(label)})) return NULL;\n"
+  if baseTyp.isRefLikeObjectType:
+    return &"  if (!GennyPy_{cIdent(name)}_AsRef({pyExpr}, &{outExpr}, {cString(label)})) return NULL;\n"
+  if baseTyp.isSeqType:
+    let seqName = baseTyp.getSeqName()
+    return &"  if (!GennyPy_{cIdent(seqName)}_AsRef({pyExpr}, &{outExpr}, {cString(label)})) return NULL;\n"
+
+  case baseTyp.nativeName()
+  of "string", "cstring":
+    &"  {outExpr} = (char *)PyUnicode_AsUTF8({pyExpr});\n" &
+    &"  if ({outExpr} == NULL) return NULL;\n"
+  of "bool":
+    &"  {{ int genny_bool = PyObject_IsTrue({pyExpr}); if (genny_bool < 0) return NULL; {outExpr} = (char)genny_bool; }}\n"
+  of "byte", "uint8":
+    &"  {{ unsigned long genny_value = PyLong_AsUnsignedLong({pyExpr}); if (PyErr_Occurred()) return NULL; if (genny_value > 255UL) {{ PyErr_Format(PyExc_OverflowError, \"%s out of range\", {cString(label)}); return NULL; }} {outExpr} = (unsigned char)genny_value; }}\n"
+  of "uint16", "uint32", "uint64", "uint":
+    &"  {{ unsigned long long genny_value = PyLong_AsUnsignedLongLong({pyExpr}); if (PyErr_Occurred()) return NULL; {outExpr} = ({cType(baseTyp)})genny_value; }}\n"
+  of "int8", "int16", "int32", "int64", "int", "Rune":
+    &"  {{ long long genny_value = PyLong_AsLongLong({pyExpr}); if (PyErr_Occurred()) return NULL; {outExpr} = ({cType(baseTyp)})genny_value; }}\n"
+  of "float32", "float64", "float":
+    &"  {{ double genny_value = PyFloat_AsDouble({pyExpr}); if (PyErr_Occurred()) return NULL; {outExpr} = ({cType(baseTyp)})genny_value; }}\n"
+  else:
+    &"  {{ long long genny_value = PyLong_AsLongLong({pyExpr}); if (PyErr_Occurred()) return NULL; {outExpr} = ({cType(baseTyp)})genny_value; }}\n"
+
+proc convertPyToCInt(pyExpr, outExpr: string, typ: NimNode, label: string): string =
+  convertPyToC(pyExpr, outExpr, typ, label).replace("return NULL", "return -1")
+
+proc addProto(procName: string, params: seq[(string, NimNode)], ret: NimNode) =
+  cProtos.add "extern " & cType(ret) & " " & procName & "("
+  for (name, typ) in params:
+    cProtos.add cDecl(typ, name) & ", "
+  cProtos.removeSuffix(", ")
+  cProtos.add ");\n"
+
+proc addModuleMethod(pyName, wrapperName: string) =
+  cModuleMethods.add &"  {{{cString(pyName)}, (PyCFunction){wrapperName}, METH_VARARGS | METH_KEYWORDS, NULL}},\n"
+
+proc addErrorCheck(procRaises: bool): string =
+  if procRaises:
+    needsErrorBridge = true
+    result.add "  if (pixie_native_check_error != NULL && pixie_native_check_error()) {\n"
+    result.add "    char *genny_error = pixie_native_take_error();\n"
+    result.add "    PyErr_SetString(GennyPy_ModuleError, genny_error ? genny_error : \"Nim exception\");\n"
+    result.add "    return NULL;\n"
+    result.add "  }\n"
+
+proc addErrorCheckInt(procRaises: bool): string =
+  if procRaises:
+    needsErrorBridge = true
+    result.add "  if (pixie_native_check_error != NULL && pixie_native_check_error()) {\n"
+    result.add "    char *genny_error = pixie_native_take_error();\n"
+    result.add "    PyErr_SetString(GennyPy_ModuleError, genny_error ? genny_error : \"Nim exception\");\n"
+    result.add "    return -1;\n"
+    result.add "  }\n"
+
+proc declareFields(objName: string, fields: seq[FieldInfo]) =
+  cTypes.add &"typedef struct {objName} {{\n"
+  for field in fields:
+    cTypes.add "  " & cDecl(field.typ, toSnakeCase(field.name)) & ";\n"
+  cTypes.add &"}} {objName};\n\n"
+
+proc arrayToPy(fieldExpr: string, fieldType: NimNode): string =
+  if not fieldType.isArrayType:
+    return pyFromC(fieldExpr, fieldType)
+  let count = fieldType[1].intVal
+  let elemType = fieldType[2]
+  let listName = "genny_list"
+  result.add &"  PyObject *{listName} = PyList_New({count});\n"
+  result.add &"  if ({listName} == NULL) return NULL;\n"
+  result.add &"  for (Py_ssize_t i = 0; i < {count}; ++i) {{\n"
+  result.add &"    PyObject *item = {pyFromC(fieldExpr & \"[i]\", elemType)};\n"
+  result.add "    if (item == NULL) { Py_DECREF(genny_list); return NULL; }\n"
+  result.add "    PyList_SET_ITEM(genny_list, i, item);\n"
+  result.add "  }\n"
+  result.add &"  return {listName};\n"
+
+proc arraySetFromPy(fieldExpr: string, fieldType: NimNode): string =
+  let count = fieldType[1].intVal
+  let elemType = fieldType[2]
+  result.add "  if (!PySequence_Check(value) || PySequence_Size(value) != " & $count & ") {\n"
+  result.add &"    PyErr_SetString(PyExc_TypeError, \"expected a sequence of length {count}\");\n"
+  result.add "    return -1;\n"
+  result.add "  }\n"
+  result.add &"  for (Py_ssize_t i = 0; i < {count}; ++i) {{\n"
+  result.add "    PyObject *item = PySequence_GetItem(value, i);\n"
+  result.add "    if (item == NULL) return -1;\n"
+  result.add &"    {cType(elemType)} converted;\n"
+  result.add convertPyToCInt("item", "converted", elemType, "array item").replace("return -1", "{ Py_DECREF(item); return -1; }")
+  result.add &"    {fieldExpr}[i] = converted;\n"
+  result.add "    Py_DECREF(item);\n"
+  result.add "  }\n"
+
+proc objectDefaultExpr(objName: string, default: NimNode): string =
+  if objName in valueObjectConstructors and valueObjectConstructors[objName] != "":
+    return valueObjectConstructors[objName] & "()"
+  result = "(" & objName & "){0}"
+  if default.kind == nnkCall and default.len > 1 and objName in valueObjectFields:
+    let fields = valueObjectFields[objName]
+    var parts: seq[string]
+    for i in 1 ..< min(default.len, fields.len + 1):
+      parts.add "." & toSnakeCase(fields[i - 1].name) & " = " & cDefaultLiteral(default[i])
+    if parts.len > 0:
+      result = "(" & objName & "){" & parts.join(", ") & "}"
+
+proc emitParamSetup(
+  procParams: seq[NimNode],
+  defaults: seq[NimNode],
+  skipFirst: bool
+): tuple[argNames, cNames, declarations, conversions, namesArray: string, required, nparams: int] =
+  var parseNames: seq[string]
+  var argVars: seq[string]
+  var required = 0
+  for i, param in procParams:
+    if skipFirst and i == 0:
+      continue
+    for j in 0 .. param.len - 3:
+      let
+        paramName = toSnakeCase(param[j].repr)
+        argVar = "arg_" & paramName
+        cVar = "c_" & paramName
+        paramType = param[^2]
+        default = defaults[i]
+      parseNames.add paramName
+      argVars.add argVar
+      if default.kind == nnkEmpty:
+        inc required
+      result.declarations.add &"  PyObject *{argVar} = NULL;\n"
+      result.declarations.add &"  {cDecl(paramType, cVar)};\n"
+      if default.kind == nnkEmpty:
+        result.conversions.add convertPyToC(argVar, cVar, paramType, paramName)
+      elif default.defaultIsSimple:
+        result.conversions.add &"  if ({argVar} == NULL) {{ {cVar} = ({cType(paramType)})({cDefaultLiteral(default)}); }} else {{\n"
+        result.conversions.add convertPyToC(argVar, cVar, paramType, paramName).indent(2)
+        result.conversions.add "  }\n"
+      else:
+        let typeName = paramType.pyTypeName()
+        if paramType.isSeqType or typeName in seqObjectNames:
+          let seqName = if paramType.isSeqType: paramType.getSeqName() else: typeName
+          result.conversions.add &"  if ({argVar} == NULL || {argVar} == Py_None) {{ {cVar} = {seqNewProcs.getOrDefault(seqName, \"$lib_new_\" & toSnakeCase(seqName))}(); }} else {{\n"
+          result.conversions.add convertPyToC(argVar, cVar, paramType, paramName).indent(2)
+          result.conversions.add "  }\n"
+        elif typeName in valueObjectNames:
+          result.conversions.add &"  if ({argVar} == NULL || {argVar} == Py_None) {{ {cVar} = {objectDefaultExpr(typeName, default)}; }} else {{\n"
+          result.conversions.add convertPyToC(argVar, cVar, paramType, paramName).indent(2)
+          result.conversions.add "  }\n"
+        else:
+          result.conversions.add &"  if ({argVar} == NULL || {argVar} == Py_None) {{ memset(&{cVar}, 0, sizeof({cVar})); }} else {{\n"
+          result.conversions.add convertPyToC(argVar, cVar, paramType, paramName).indent(2)
+          result.conversions.add "  }\n"
+      result.cNames.add cVar & ", "
+  result.cNames.removeSuffix(", ")
+  result.namesArray = "  const char *genny_names[] = {"
+  for name in parseNames:
+    result.namesArray.add cString(name) & ", "
+  result.namesArray.add "NULL};\n"
+  result.argNames = argVars.join(", &")
+  if result.argNames.len > 0:
+    result.argNames = "&" & result.argNames
+  result.required = required
+  result.nparams = parseNames.len
+
+proc exportProcPyNative*(
+  sym: NimNode,
+  owner: NimNode = nil,
+  prefixes: openarray[NimNode] = []
+) =
+  let
+    procType = sym.getTypeInst()
+    procParams = procType[0][1 .. ^1]
+    procReturn = procType[0][0]
+    procRaises = sym.raises()
+    apiName = apiProcName(sym, owner, prefixes)
+    pyName = pyProcName(sym, owner, prefixes)
+    wrapperName = "GennyPy_wrap_" & cIdent(apiName)
+    defaults = getDefaults(sym)
+    onType = owner != nil
+    ownerTypeName = if owner == nil: "" else: owner.pyTypeName()
+
+  var protoParams: seq[(string, NimNode)]
+  for param in procParams:
+    for i in 0 .. param.len - 3:
+      protoParams.add((toSnakeCase(param[i].repr), param[^2]))
+  addProto(apiName, protoParams, procReturn)
+
+  if procRaises:
+    needsErrorBridge = true
+
+  cForwardDecls.add &"static PyObject *{wrapperName}(PyObject *self, PyObject *args, PyObject *kwargs);\n"
+
+  let skipFirst = onType
+  let setup = emitParamSetup(procParams, defaults, skipFirst)
+
+  cWrappers.add &"static PyObject *{wrapperName}(PyObject *self, PyObject *args, PyObject *kwargs) {{\n"
+  cWrappers.add setup.namesArray
+  cWrappers.add setup.declarations
+  cWrappers.add &"  if (!genny_parse_args({cString(pyName)}, args, kwargs, {setup.nparams}, genny_names, {setup.required}"
+  if setup.nparams > 0:
+    cWrappers.add ", " & setup.argNames
+  cWrappers.add ")) return NULL;\n"
+  cWrappers.add setup.conversions
+
+  var callArgs = setup.cNames
+  if onType:
+    let selfCast = "((" & pyStructName(ownerTypeName) & " *)self)"
+    if ownerTypeName in valueObjectNames:
+      callArgs = selfCast & "->value" & (if callArgs.len > 0: ", " & callArgs else: "")
+    else:
+      callArgs = selfCast & "->ref" & (if callArgs.len > 0: ", " & callArgs else: "")
+
+  if procReturn.isVoid:
+    cWrappers.add &"  {apiName}({callArgs});\n"
+    cWrappers.add addErrorCheck(procRaises)
+    cWrappers.add "  Py_RETURN_NONE;\n"
+  else:
+    cWrappers.add &"  {cType(procReturn)} genny_result = {apiName}({callArgs});\n"
+    cWrappers.add addErrorCheck(procRaises)
+    cWrappers.add &"  return {pyFromC(\"genny_result\", procReturn)};\n"
+  cWrappers.add "}\n\n"
+
+  if not onType:
+    addModuleMethod(pyName, wrapperName)
+  else:
+    typeMethods[ownerTypeName] = typeMethods.getOrDefault(ownerTypeName) &
+      &"  {{{cString(pyName)}, (PyCFunction){wrapperName}, METH_VARARGS | METH_KEYWORDS, NULL}},\n"
+
+proc emitValueObjectType(objName: string, fields: seq[FieldInfo], constructor: NimNode) =
+  let
+    pyStruct = pyStructName(objName)
+    typeObj = typeObjName(objName)
+    ctorName = if constructor != nil: "$lib_" & toSnakeCase(objName) else: "$lib_" & toSnakeCase(objName)
+    initName = &"GennyPy_{cIdent(objName)}_init"
+    newName = &"GennyPy_{cIdent(objName)}_new"
+    deallocName = &"GennyPy_{cIdent(objName)}_dealloc"
+    richName = &"GennyPy_{cIdent(objName)}_richcompare"
+    fromValueName = &"GennyPy_{cIdent(objName)}_FromValue"
+    asValueName = &"GennyPy_{cIdent(objName)}_AsValue"
+
+  cForwardDecls.add &"static PyTypeObject {typeObj};\n"
+  cForwardDecls.add &"static PyObject *{fromValueName}({objName} value);\n"
+  cForwardDecls.add &"static int {asValueName}(PyObject *obj, {objName} *out, const char *name);\n"
+
+  cTypeBlocks.add &"typedef struct {{ PyObject_HEAD {objName} value; PyObject *dict; }} {pyStruct};\n\n"
+  cTypeBlocks.add &"static PyObject *{newName}(PyTypeObject *type, PyObject *args, PyObject *kwargs) {{\n"
+  cTypeBlocks.add &"  {pyStruct} *self = ({pyStruct} *)type->tp_alloc(type, 0);\n"
+  cTypeBlocks.add "  if (self != NULL) { memset(&self->value, 0, sizeof(self->value)); self->dict = NULL; }\n"
+  cTypeBlocks.add "  return (PyObject *)self;\n"
+  cTypeBlocks.add "}\n\n"
+  cTypeBlocks.add &"static void {deallocName}({pyStruct} *self) {{\n"
+  cTypeBlocks.add "  Py_XDECREF(self->dict);\n"
+  cTypeBlocks.add "  Py_TYPE(self)->tp_free((PyObject *)self);\n"
+  cTypeBlocks.add "}\n\n"
+
+  var ctorParams: seq[NimNode]
+  if constructor != nil:
+    let ctype = constructor.getTypeInst()
+    ctorParams = ctype[0][1 .. ^1]
+    var protoParams: seq[(string, NimNode)]
+    for param in ctorParams:
+      for i in 0 .. param.len - 3:
+        protoParams.add((toSnakeCase(param[i].repr), param[^2]))
+    addProto(ctorName, protoParams, ident(objName))
+  else:
+    var protoParams: seq[(string, NimNode)]
+    for field in fields:
+      protoParams.add((toSnakeCase(field.name), field.typ))
+    addProto(ctorName, protoParams, ident(objName))
+
+  cTypeBlocks.add &"static int {initName}({pyStruct} *self, PyObject *args, PyObject *kwargs) {{\n"
+  if constructor != nil:
+    let setup = emitParamSetup(ctorParams, getDefaults(constructor), false)
+    cTypeBlocks.add setup.namesArray
+    cTypeBlocks.add setup.declarations
+    cTypeBlocks.add &"  if (!genny_parse_args({cString(objName)}, args, kwargs, {setup.nparams}, genny_names, {setup.required}"
+    if setup.nparams > 0:
+      cTypeBlocks.add ", " & setup.argNames
+    cTypeBlocks.add ")) return -1;\n"
+    cTypeBlocks.add setup.conversions.replace("return NULL", "return -1")
+    cTypeBlocks.add &"  self->value = {ctorName}({setup.cNames});\n"
+  else:
+    cTypeBlocks.add "  const char *genny_names[] = {"
+    for field in fields:
+      cTypeBlocks.add cString(toSnakeCase(field.name)) & ", "
+    cTypeBlocks.add "NULL};\n"
+    for field in fields:
+      cTypeBlocks.add &"  PyObject *arg_{toSnakeCase(field.name)} = NULL;\n"
+      cTypeBlocks.add &"  {cDecl(field.typ, \"c_\" & toSnakeCase(field.name))};\n"
+    cTypeBlocks.add &"  if (!genny_parse_args({cString(objName)}, args, kwargs, {fields.len}, genny_names, {fields.len}"
+    if fields.len > 0:
+      cTypeBlocks.add ", "
+      for field in fields:
+        cTypeBlocks.add &"&arg_{toSnakeCase(field.name)}, "
+      cTypeBlocks.removeSuffix(", ")
+    cTypeBlocks.add ")) return -1;\n"
+    for field in fields:
+      cTypeBlocks.add convertPyToCInt("arg_" & toSnakeCase(field.name), "c_" & toSnakeCase(field.name), field.typ, toSnakeCase(field.name))
+    cTypeBlocks.add &"  self->value = {ctorName}("
+    for field in fields:
+      cTypeBlocks.add "c_" & toSnakeCase(field.name) & ", "
+    cTypeBlocks.removeSuffix(", ")
+    cTypeBlocks.add ");\n"
+  cTypeBlocks.add "  return 0;\n"
+  cTypeBlocks.add "}\n\n"
+
+  for field in fields:
+    let
+      fieldSnake = toSnakeCase(field.name)
+      getter = &"GennyPy_{cIdent(objName)}_get_{fieldSnake}"
+      setter = &"GennyPy_{cIdent(objName)}_set_{fieldSnake}"
+      fieldExpr = &"self->value.{fieldSnake}"
+    cTypeBlocks.add &"static PyObject *{getter}({pyStruct} *self, void *closure) {{\n"
+    if field.typ.isArrayType:
+      cTypeBlocks.add arrayToPy(fieldExpr, field.typ)
+    else:
+      cTypeBlocks.add &"  return {pyFromC(fieldExpr, field.typ)};\n"
+    cTypeBlocks.add "}\n\n"
+    cTypeBlocks.add &"static int {setter}({pyStruct} *self, PyObject *value, void *closure) {{\n"
+    cTypeBlocks.add "  if (value == NULL) { PyErr_SetString(PyExc_TypeError, \"cannot delete field\"); return -1; }\n"
+    if field.typ.isArrayType:
+      cTypeBlocks.add arraySetFromPy(fieldExpr, field.typ)
+    else:
+      cTypeBlocks.add "  " & cDecl(field.typ, "converted") & ";\n"
+      cTypeBlocks.add convertPyToCInt("value", "converted", field.typ, fieldSnake)
+      cTypeBlocks.add &"  {fieldExpr} = converted;\n"
+    cTypeBlocks.add "  return 0;\n"
+    cTypeBlocks.add "}\n\n"
+
+  addProto("$lib_" & toSnakeCase(objName) & "_eq", @[("a", ident(objName)), ("b", ident(objName))], ident("bool"))
+  cTypeBlocks.add &"static PyObject *{richName}(PyObject *a, PyObject *b, int op) {{\n"
+  cTypeBlocks.add &"  if (!PyObject_TypeCheck(a, &{typeObj}) || !PyObject_TypeCheck(b, &{typeObj})) {{ Py_RETURN_NOTIMPLEMENTED; }}\n"
+  cTypeBlocks.add &"  int eq = $lib_{toSnakeCase(objName)}_eq((({pyStruct} *)a)->value, (({pyStruct} *)b)->value);\n"
+  cTypeBlocks.add "  if (op == Py_EQ) return PyBool_FromLong(eq);\n"
+  cTypeBlocks.add "  if (op == Py_NE) return PyBool_FromLong(!eq);\n"
+  cTypeBlocks.add "  Py_RETURN_NOTIMPLEMENTED;\n"
+  cTypeBlocks.add "}\n\n"
+
+  cTypeBlocks.add &"static PyObject *{fromValueName}({objName} value) {{\n"
+  cTypeBlocks.add &"  {pyStruct} *self = PyObject_New({pyStruct}, &{typeObj});\n"
+  cTypeBlocks.add "  if (self == NULL) return NULL;\n"
+  cTypeBlocks.add "  self->value = value;\n"
+  cTypeBlocks.add "  self->dict = NULL;\n"
+  cTypeBlocks.add "  return (PyObject *)self;\n"
+  cTypeBlocks.add "}\n\n"
+  cTypeBlocks.add &"static int {asValueName}(PyObject *obj, {objName} *out, const char *name) {{\n"
+  cTypeBlocks.add &"  if (!PyObject_TypeCheck(obj, &{typeObj})) {{ PyErr_Format(PyExc_TypeError, \"%s must be {objName}\", name); return 0; }}\n"
+  cTypeBlocks.add &"  *out = (({pyStruct} *)obj)->value;\n"
+  cTypeBlocks.add "  return 1;\n"
+  cTypeBlocks.add "}\n\n"
+
+  cTypeBlocks.add &"static PyGetSetDef GennyPy_{cIdent(objName)}_getset[] = {{\n"
+  for field in fields:
+    let fieldSnake = toSnakeCase(field.name)
+    cTypeBlocks.add &"  {{{cString(fieldSnake)}, (getter)GennyPy_{cIdent(objName)}_get_{fieldSnake}, (setter)GennyPy_{cIdent(objName)}_set_{fieldSnake}, NULL, NULL}},\n"
+  cTypeBlocks.add "  {NULL}\n};\n\n"
+  cTypeBlocks.add &"static PyMethodDef GennyPy_{cIdent(objName)}_methods[] = {{\n"
+  cTypeBlocks.add &"/* GENNY_METHODS_{cIdent(objName)} */\n"
+  cTypeBlocks.add "  {NULL}\n};\n\n"
+  cTypeBlocks.add &"static PyTypeObject {typeObj} = {{\n"
+  cTypeBlocks.add "  PyVarObject_HEAD_INIT(NULL, 0)\n"
+  cTypeBlocks.add &"  .tp_name = {cString(\"$lib.\" & objName)},\n"
+  cTypeBlocks.add &"  .tp_basicsize = sizeof({pyStruct}),\n"
+  cTypeBlocks.add "  .tp_itemsize = 0,\n"
+  cTypeBlocks.add &"  .tp_dealloc = (destructor){deallocName},\n"
+  cTypeBlocks.add "  .tp_flags = Py_TPFLAGS_DEFAULT,\n"
+  cTypeBlocks.add &"  .tp_dictoffset = offsetof({pyStruct}, dict),\n"
+  cTypeBlocks.add &"  .tp_new = {newName},\n"
+  cTypeBlocks.add &"  .tp_init = (initproc){initName},\n"
+  cTypeBlocks.add &"  .tp_richcompare = {richName},\n"
+  cTypeBlocks.add &"  .tp_methods = GennyPy_{cIdent(objName)}_methods,\n"
+  cTypeBlocks.add &"  .tp_getset = GennyPy_{cIdent(objName)}_getset,\n"
+  cTypeBlocks.add "};\n\n"
+  cModuleInit.add &"  if (PyType_Ready(&{typeObj}) < 0) return NULL;\n"
+  cModuleInit.add &"  Py_INCREF(&{typeObj});\n"
+  cModuleInit.add &"  if (PyModule_AddObject(m, {cString(objName)}, (PyObject *)&{typeObj}) < 0) return NULL;\n"
+
+proc exportObjectPyNative*(sym: NimNode, constructor: NimNode) =
+  let objName = sym.nativeName()
+  valueObjectNames.incl(objName)
+
+  var fields: seq[FieldInfo]
+  for identDefs in sym.getImpl()[2][2]:
+    for property in identDefs[0 .. ^3]:
+      fields.add((property[1].repr, identDefs[^2]))
+  valueObjectFields[objName] = fields
+  valueObjectConstructors[objName] = if constructor != nil: "$lib_" & toSnakeCase(objName) else: ""
+  declareFields(objName, fields)
+  emitValueObjectType(objName, fields, constructor)
+
+proc emitRefLikeType(objName: string, constructor: NimNode, isSeq = false, entryType: NimNode = nil)
+proc emitSeqMethods(objName, procPrefix, refExpr, typePrefix: string, entryType: NimNode, abiObjName = "")
+
+proc emitRefLikeType(objName: string, constructor: NimNode, isSeq = false, entryType: NimNode = nil) =
+  let
+    pyStruct = pyStructName(objName)
+    typeObj = typeObjName(objName)
+    newName = &"GennyPy_{cIdent(objName)}_new"
+    initName = &"GennyPy_{cIdent(objName)}_init"
+    deallocName = &"GennyPy_{cIdent(objName)}_dealloc"
+    boolName = &"GennyPy_{cIdent(objName)}_bool"
+    richName = &"GennyPy_{cIdent(objName)}_richcompare"
+    fromRefName = &"GennyPy_{cIdent(objName)}_FromRef"
+    asRefName = &"GennyPy_{cIdent(objName)}_AsRef"
+    unrefName = "$lib_" & toSnakeCase(objName) & "_unref"
+
+  cForwardDecls.add &"static PyTypeObject {typeObj};\n"
+  cForwardDecls.add &"static PyObject *{fromRefName}(void *ref);\n"
+  cForwardDecls.add &"static int {asRefName}(PyObject *obj, void **out, const char *name);\n"
+  cTypeBlocks.add &"typedef struct {{ PyObject_HEAD void *ref; PyObject *dict; }} {pyStruct};\n\n"
+  addProto(unrefName, @[(toSnakeCase(objName), ident(objName))], newEmptyNode())
+
+  cTypeBlocks.add &"static PyObject *{newName}(PyTypeObject *type, PyObject *args, PyObject *kwargs) {{\n"
+  cTypeBlocks.add &"  {pyStruct} *self = ({pyStruct} *)type->tp_alloc(type, 0);\n"
+  cTypeBlocks.add "  if (self != NULL) { self->ref = NULL; self->dict = NULL; }\n"
+  cTypeBlocks.add "  return (PyObject *)self;\n"
+  cTypeBlocks.add "}\n\n"
+  cTypeBlocks.add &"static void {deallocName}({pyStruct} *self) {{\n"
+  cTypeBlocks.add &"  if (self->ref != NULL) {{ {unrefName}(self->ref); self->ref = NULL; }}\n"
+  cTypeBlocks.add "  Py_XDECREF(self->dict);\n"
+  cTypeBlocks.add "  Py_TYPE(self)->tp_free((PyObject *)self);\n"
+  cTypeBlocks.add "}\n\n"
+  cTypeBlocks.add &"static int {boolName}({pyStruct} *self) {{ return self->ref != NULL; }}\n\n"
+  cTypeBlocks.add &"static PyObject *GennyPy_{cIdent(objName)}_get_ref({pyStruct} *self, void *closure) {{ return PyLong_FromVoidPtr(self->ref); }}\n\n"
+  cTypeBlocks.add &"static PyObject *{richName}(PyObject *a, PyObject *b, int op) {{\n"
+  cTypeBlocks.add &"  if (!PyObject_TypeCheck(a, &{typeObj}) || !PyObject_TypeCheck(b, &{typeObj})) {{ Py_RETURN_NOTIMPLEMENTED; }}\n"
+  cTypeBlocks.add &"  int eq = (({pyStruct} *)a)->ref == (({pyStruct} *)b)->ref;\n"
+  cTypeBlocks.add "  if (op == Py_EQ) return PyBool_FromLong(eq);\n"
+  cTypeBlocks.add "  if (op == Py_NE) return PyBool_FromLong(!eq);\n"
+  cTypeBlocks.add "  Py_RETURN_NOTIMPLEMENTED;\n"
+  cTypeBlocks.add "}\n\n"
+  cTypeBlocks.add &"static PyObject *{fromRefName}(void *ref) {{\n"
+  cTypeBlocks.add &"  {pyStruct} *self = PyObject_New({pyStruct}, &{typeObj});\n"
+  cTypeBlocks.add "  if (self == NULL) return NULL;\n"
+  cTypeBlocks.add "  self->ref = ref;\n"
+  cTypeBlocks.add "  self->dict = NULL;\n"
+  cTypeBlocks.add "  return (PyObject *)self;\n"
+  cTypeBlocks.add "}\n\n"
+  cTypeBlocks.add &"static int {asRefName}(PyObject *obj, void **out, const char *name) {{\n"
+  cTypeBlocks.add &"  if (!PyObject_TypeCheck(obj, &{typeObj})) {{ PyErr_Format(PyExc_TypeError, \"%s must be {objName}\", name); return 0; }}\n"
+  cTypeBlocks.add &"  *out = (({pyStruct} *)obj)->ref;\n"
+  cTypeBlocks.add "  return 1;\n"
+  cTypeBlocks.add "}\n\n"
+
+  cTypeBlocks.add &"static int {initName}({pyStruct} *self, PyObject *args, PyObject *kwargs) {{\n"
+  if isSeq:
+    let newSeq = "$lib_new_" & toSnakeCase(objName)
+    addProto(newSeq, @[], ident(objName))
+    cTypeBlocks.add &"  if (!genny_parse_args({cString(objName)}, args, kwargs, 0, NULL, 0)) return -1;\n"
+    cTypeBlocks.add &"  self->ref = {newSeq}();\n"
+  elif constructor != nil:
+    let
+      constructorApi = "$lib_" & toSnakeCase(constructor.repr)
+      ctype = constructor.getTypeInst()
+      ctorParams = ctype[0][1 .. ^1]
+      setup = emitParamSetup(ctorParams, getDefaults(constructor), false)
+    var protoParams: seq[(string, NimNode)]
+    for param in ctorParams:
+      for i in 0 .. param.len - 3:
+        protoParams.add((toSnakeCase(param[i].repr), param[^2]))
+    addProto(constructorApi, protoParams, ident(objName))
+    cTypeBlocks.add setup.namesArray
+    cTypeBlocks.add setup.declarations
+    cTypeBlocks.add &"  if (!genny_parse_args({cString(objName)}, args, kwargs, {setup.nparams}, genny_names, {setup.required}"
+    if setup.nparams > 0:
+      cTypeBlocks.add ", " & setup.argNames
+    cTypeBlocks.add ")) return -1;\n"
+    cTypeBlocks.add setup.conversions.replace("return NULL", "return -1")
+    cTypeBlocks.add &"  self->ref = {constructorApi}({setup.cNames});\n"
+    cTypeBlocks.add addErrorCheckInt(constructor.raises())
+  else:
+    cTypeBlocks.add &"  if (!genny_parse_args({cString(objName)}, args, kwargs, 0, NULL, 0)) return -1;\n"
+    cTypeBlocks.add "  self->ref = NULL;\n"
+  cTypeBlocks.add "  return 0;\n"
+  cTypeBlocks.add "}\n\n"
+
+  cTypeBlocks.add &"static PyNumberMethods GennyPy_{cIdent(objName)}_number = {{ .nb_bool = (inquiry){boolName} }};\n\n"
+  if isSeq:
+    emitSeqMethods(objName, "$lib_" & toSnakeCase(objName), &"(({pyStruct} *)self)->ref", "GennyPy_" & cIdent(objName), entryType)
+
+  cTypeBlocks.add &"static PyMethodDef GennyPy_{cIdent(objName)}_methods[] = {{\n"
+  if isSeq:
+    cTypeBlocks.add &"  {{{cString(\"append\")}, (PyCFunction)GennyPy_{cIdent(objName)}_append, METH_O, NULL}},\n"
+    cTypeBlocks.add &"  {{{cString(\"add\")}, (PyCFunction)GennyPy_{cIdent(objName)}_append, METH_O, NULL}},\n"
+    cTypeBlocks.add &"  {{{cString(\"clear\")}, (PyCFunction)GennyPy_{cIdent(objName)}_clear, METH_NOARGS, NULL}},\n"
+  cTypeBlocks.add &"/* GENNY_METHODS_{cIdent(objName)} */\n"
+  cTypeBlocks.add "  {NULL}\n};\n\n"
+
+  cTypeBlocks.add &"static PyGetSetDef GennyPy_{cIdent(objName)}_getset[] = {{\n"
+  cTypeBlocks.add &"  {{{cString(\"ref\")}, (getter)GennyPy_{cIdent(objName)}_get_ref, NULL, NULL, NULL}},\n"
+  cTypeBlocks.add "  {NULL}\n};\n\n"
+  cTypeBlocks.add &"static PyTypeObject {typeObj} = {{\n"
+  cTypeBlocks.add "  PyVarObject_HEAD_INIT(NULL, 0)\n"
+  cTypeBlocks.add &"  .tp_name = {cString(\"$lib.\" & objName)},\n"
+  cTypeBlocks.add &"  .tp_basicsize = sizeof({pyStruct}),\n"
+  cTypeBlocks.add "  .tp_itemsize = 0,\n"
+  cTypeBlocks.add &"  .tp_dealloc = (destructor){deallocName},\n"
+  cTypeBlocks.add "  .tp_flags = Py_TPFLAGS_DEFAULT,\n"
+  cTypeBlocks.add &"  .tp_dictoffset = offsetof({pyStruct}, dict),\n"
+  cTypeBlocks.add &"  .tp_new = {newName},\n"
+  cTypeBlocks.add &"  .tp_init = (initproc){initName},\n"
+  cTypeBlocks.add &"  .tp_richcompare = {richName},\n"
+  cTypeBlocks.add &"  .tp_as_number = &GennyPy_{cIdent(objName)}_number,\n"
+  if isSeq:
+    cTypeBlocks.add &"  .tp_as_sequence = &GennyPy_{cIdent(objName)}_sequence,\n"
+  cTypeBlocks.add &"  .tp_methods = GennyPy_{cIdent(objName)}_methods,\n"
+  cTypeBlocks.add &"  .tp_getset = GennyPy_{cIdent(objName)}_getset,\n"
+  cTypeBlocks.add "};\n\n"
+  cModuleInit.add &"  if (PyType_Ready(&{typeObj}) < 0) return NULL;\n"
+  cModuleInit.add &"  Py_INCREF(&{typeObj});\n"
+  cModuleInit.add &"  if (PyModule_AddObject(m, {cString(objName)}, (PyObject *)&{typeObj}) < 0) return NULL;\n"
+
+proc emitSeqMethods(objName, procPrefix, refExpr, typePrefix: string, entryType: NimNode, abiObjName = "") =
+  let abiName = if abiObjName.len > 0: abiObjName else: objName
+  addProto(procPrefix & "_len", @[(toSnakeCase(abiName), ident(abiName))], ident("int"))
+  addProto(procPrefix & "_get", @[(toSnakeCase(abiName), ident(abiName)), ("i", ident("int"))], entryType)
+  addProto(procPrefix & "_set", @[(toSnakeCase(abiName), ident(abiName)), ("i", ident("int")), ("v", entryType)], newEmptyNode())
+  addProto(procPrefix & "_delete", @[(toSnakeCase(abiName), ident(abiName)), ("i", ident("int"))], newEmptyNode())
+  addProto(procPrefix & "_add", @[(toSnakeCase(abiName), ident(abiName)), ("v", entryType)], newEmptyNode())
+  addProto(procPrefix & "_clear", @[(toSnakeCase(abiName), ident(abiName))], newEmptyNode())
+
+  cTypeBlocks.add &"static Py_ssize_t {typePrefix}_len(PyObject *self) {{ return (Py_ssize_t){procPrefix}_len({refExpr}); }}\n\n"
+  cTypeBlocks.add &"static PyObject *{typePrefix}_item(PyObject *self, Py_ssize_t index) {{\n"
+  cTypeBlocks.add &"  Py_ssize_t len = {typePrefix}_len(self);\n"
+  cTypeBlocks.add "  if (index < 0) index += len;\n"
+  cTypeBlocks.add "  if (index < 0 || index >= len) { PyErr_SetString(PyExc_IndexError, \"index out of range\"); return NULL; }\n"
+  cTypeBlocks.add &"  {cType(entryType)} value = {procPrefix}_get({refExpr}, (long long)index);\n"
+  cTypeBlocks.add &"  return {pyFromC(\"value\", entryType)};\n"
+  cTypeBlocks.add "}\n\n"
+  cTypeBlocks.add &"static int {typePrefix}_ass_item(PyObject *self, Py_ssize_t index, PyObject *value) {{\n"
+  cTypeBlocks.add &"  Py_ssize_t len = {typePrefix}_len(self);\n"
+  cTypeBlocks.add "  if (index < 0) index += len;\n"
+  cTypeBlocks.add "  if (index < 0 || index >= len) { PyErr_SetString(PyExc_IndexError, \"index out of range\"); return -1; }\n"
+  cTypeBlocks.add &"  if (value == NULL) {{ {procPrefix}_delete({refExpr}, (long long)index); return 0; }}\n"
+  cTypeBlocks.add &"  {cType(entryType)} converted;\n"
+  cTypeBlocks.add convertPyToCInt("value", "converted", entryType, "value")
+  cTypeBlocks.add &"  {procPrefix}_set({refExpr}, (long long)index, converted);\n"
+  cTypeBlocks.add "  return 0;\n"
+  cTypeBlocks.add "}\n\n"
+  cTypeBlocks.add &"static PyObject *{typePrefix}_append(PyObject *self, PyObject *value) {{\n"
+  cTypeBlocks.add &"  {cType(entryType)} converted;\n"
+  cTypeBlocks.add convertPyToC("value", "converted", entryType, "value")
+  cTypeBlocks.add &"  {procPrefix}_add({refExpr}, converted);\n"
+  cTypeBlocks.add "  Py_RETURN_NONE;\n"
+  cTypeBlocks.add "}\n\n"
+  cTypeBlocks.add &"static PyObject *{typePrefix}_clear(PyObject *self, PyObject *Py_UNUSED(ignored)) {{\n"
+  cTypeBlocks.add &"  {procPrefix}_clear({refExpr});\n"
+  cTypeBlocks.add "  Py_RETURN_NONE;\n"
+  cTypeBlocks.add "}\n\n"
+  cTypeBlocks.add &"static PySequenceMethods {typePrefix}_sequence = {{\n"
+  cTypeBlocks.add &"  .sq_length = {typePrefix}_len,\n"
+  cTypeBlocks.add &"  .sq_item = {typePrefix}_item,\n"
+  cTypeBlocks.add &"  .sq_ass_item = {typePrefix}_ass_item,\n"
+  cTypeBlocks.add "};\n\n"
+
+proc exportRefObjectPyNative*(
+  sym: NimNode,
+  fields: seq[(string, NimNode)],
+  constructor: NimNode
+) =
+  let objName = sym.nativeName()
+  refObjectNames.incl(objName)
+  emitRefLikeType(objName, constructor)
+
+  var getsetForwardDecls = ""
+  for (fieldName, fieldType) in fields:
+    let
+      fieldSnake = toSnakeCase(fieldName)
+      objSnake = toSnakeCase(objName)
+      pyStruct = pyStructName(objName)
+
+    if fieldType.isSeqType:
+      let
+        entryType = fieldType[1]
+        helperName = objName & capitalizeAscii(fieldName)
+        helperStruct = pyStructName(helperName)
+        helperType = typeObjName(helperName)
+        procPrefix = "$lib_" & objSnake & "_" & fieldSnake
+        getterName = &"GennyPy_{cIdent(objName)}_get_{fieldSnake}"
+
+      getsetForwardDecls.add &"static PyObject *{getterName}({pyStruct} *self, void *closure);\n"
+      cForwardDecls.add &"static PyTypeObject {helperType};\n"
+      cTypeBlocks.add &"typedef struct {{ PyObject_HEAD PyObject *parent; PyObject *dict; }} {helperStruct};\n\n"
+      cTypeBlocks.add &"static void GennyPy_{cIdent(helperName)}_dealloc({helperStruct} *self) {{ Py_XDECREF(self->parent); Py_XDECREF(self->dict); Py_TYPE(self)->tp_free((PyObject *)self); }}\n\n"
+      cTypeBlocks.add &"static PyObject *GennyPy_{cIdent(helperName)}_from_parent(PyObject *parent) {{\n"
+      cTypeBlocks.add &"  {helperStruct} *self = PyObject_New({helperStruct}, &{helperType});\n"
+      cTypeBlocks.add "  if (self == NULL) return NULL;\n"
+      cTypeBlocks.add "  Py_INCREF(parent);\n"
+      cTypeBlocks.add "  self->parent = parent;\n"
+      cTypeBlocks.add "  self->dict = NULL;\n"
+      cTypeBlocks.add "  return (PyObject *)self;\n"
+      cTypeBlocks.add "}\n\n"
+      emitSeqMethods(helperName, procPrefix, &"(({pyStruct} *)(({helperStruct} *)self)->parent)->ref", "GennyPy_" & cIdent(helperName), entryType, objName)
+      cTypeBlocks.add &"static PyMethodDef GennyPy_{cIdent(helperName)}_methods[] = {{\n"
+      cTypeBlocks.add &"  {{{cString(\"append\")}, (PyCFunction)GennyPy_{cIdent(helperName)}_append, METH_O, NULL}},\n"
+      cTypeBlocks.add &"  {{{cString(\"add\")}, (PyCFunction)GennyPy_{cIdent(helperName)}_append, METH_O, NULL}},\n"
+      cTypeBlocks.add &"  {{{cString(\"clear\")}, (PyCFunction)GennyPy_{cIdent(helperName)}_clear, METH_NOARGS, NULL}},\n"
+      cTypeBlocks.add "  {NULL}\n};\n\n"
+      cTypeBlocks.add &"static PyTypeObject {helperType} = {{\n"
+      cTypeBlocks.add "  PyVarObject_HEAD_INIT(NULL, 0)\n"
+      cTypeBlocks.add &"  .tp_name = {cString(\"$lib.\" & helperName)},\n"
+      cTypeBlocks.add &"  .tp_basicsize = sizeof({helperStruct}),\n"
+      cTypeBlocks.add &"  .tp_dealloc = (destructor)GennyPy_{cIdent(helperName)}_dealloc,\n"
+      cTypeBlocks.add "  .tp_flags = Py_TPFLAGS_DEFAULT,\n"
+      cTypeBlocks.add &"  .tp_dictoffset = offsetof({helperStruct}, dict),\n"
+      cTypeBlocks.add &"  .tp_as_sequence = &GennyPy_{cIdent(helperName)}_sequence,\n"
+      cTypeBlocks.add &"  .tp_methods = GennyPy_{cIdent(helperName)}_methods,\n"
+      cTypeBlocks.add "};\n\n"
+      cTypeBlocks.add &"static PyObject *{getterName}({pyStruct} *self, void *closure) {{ return GennyPy_{cIdent(helperName)}_from_parent((PyObject *)self); }}\n\n"
+      cModuleInit.add &"  if (PyType_Ready(&{helperType}) < 0) return NULL;\n"
+      cModuleInit.add &"  Py_INCREF(&{helperType});\n"
+    else:
+      let
+        getterApi = "$lib_" & objSnake & "_get_" & fieldSnake
+        setterApi = "$lib_" & objSnake & "_set_" & fieldSnake
+        getterName = &"GennyPy_{cIdent(objName)}_get_{fieldSnake}"
+        setterName = &"GennyPy_{cIdent(objName)}_set_{fieldSnake}"
+      addProto(getterApi, @[(objSnake, sym)], fieldType)
+      addProto(setterApi, @[(objSnake, sym), ("value", fieldType)], newEmptyNode())
+      getsetForwardDecls.add &"static PyObject *{getterName}({pyStruct} *self, void *closure);\n"
+      getsetForwardDecls.add &"static int {setterName}({pyStruct} *self, PyObject *value, void *closure);\n"
+      cTypeBlocks.add &"static PyObject *{getterName}({pyStruct} *self, void *closure) {{\n"
+      cTypeBlocks.add &"  {cType(fieldType)} value = {getterApi}(self->ref);\n"
+      cTypeBlocks.add &"  return {pyFromC(\"value\", fieldType)};\n"
+      cTypeBlocks.add "}\n\n"
+      cTypeBlocks.add &"static int {setterName}({pyStruct} *self, PyObject *value, void *closure) {{\n"
+      cTypeBlocks.add "  if (value == NULL) { PyErr_SetString(PyExc_TypeError, \"cannot delete field\"); return -1; }\n"
+      cTypeBlocks.add &"  {cType(fieldType)} converted;\n"
+      cTypeBlocks.add convertPyToCInt("value", "converted", fieldType, fieldSnake)
+      cTypeBlocks.add &"  {setterApi}(self->ref, converted);\n"
+      cTypeBlocks.add "  return 0;\n"
+      cTypeBlocks.add "}\n\n"
+
+  var getsetName = &"GennyPy_{cIdent(objName)}_getset"
+  let marker = &"static PyGetSetDef {getsetName}[] = {{\n"
+  var replacement = getsetForwardDecls & marker
+  for (fieldName, fieldType) in fields:
+    let fieldSnake = toSnakeCase(fieldName)
+    let setter =
+      if fieldType.isSeqType: "NULL"
+      else: "(setter)GennyPy_" & cIdent(objName) & "_set_" & fieldSnake
+    replacement.add &"  {{{cString(fieldSnake)}, (getter)GennyPy_{cIdent(objName)}_get_{fieldSnake}, {setter}, NULL, NULL}},\n"
+  cTypeBlocks = cTypeBlocks.replace(marker, replacement)
+
+proc exportSeqPyNative*(sym: NimNode) =
+  let
+    seqName = sym.getName()
+    entryType = sym[1]
+  seqObjectNames.incl(seqName)
+  seqEntryTypes[seqName] = entryType
+  seqNewProcs[seqName] = "$lib_new_" & toSnakeCase(seqName)
+  emitRefLikeType(seqName, nil, true, entryType)
+
+proc exportConstPyNative*(sym: NimNode) =
+  let
+    name = toCapSnakeCase(sym.repr)
+    value = sym.getImpl()[2].repr
+    cValue =
+      if value == "true": "1"
+      elif value == "false": "0"
+      else: value
+  cTypes.add &"#define {name} {cValue}\n"
+  if value.contains(".") or value.contains("e") or value.contains("E"):
+    cModuleInit.add &"  if (PyModule_AddObject(m, {cString(name)}, PyFloat_FromDouble((double)({value}))) < 0) return NULL;\n"
+  elif value == "true" or value == "false":
+    let boolValue = if value == "true": "1" else: "0"
+    cModuleInit.add &"  if (PyModule_AddIntConstant(m, {cString(name)}, {boolValue}) < 0) return NULL;\n"
+  elif value.startsWith("\""):
+    cModuleInit.add &"  if (PyModule_AddObject(m, {cString(name)}, PyUnicode_FromString({value})) < 0) return NULL;\n"
+  else:
+    cModuleInit.add &"  if (PyModule_AddObject(m, {cString(name)}, PyLong_FromLongLong((long long)({value}))) < 0) return NULL;\n"
+
+proc exportEnumPyNative*(sym: NimNode) =
+  enumTypeNames.incl(sym.repr)
+  cModuleInit.add &"  Py_INCREF(&PyLong_Type);\n"
+  cModuleInit.add &"  if (PyModule_AddObject(m, {cString(sym.repr)}, (PyObject *)&PyLong_Type) < 0) return NULL;\n"
+  for i, entry in sym.getImpl()[2][1 .. ^1]:
+    let name = toCapSnakeCase(entry.repr)
+    cTypes.add &"#define {name} {i}\n"
+    cModuleInit.add &"  if (PyModule_AddIntConstant(m, {cString(name)}, {i}) < 0) return NULL;\n"
+
+proc pythonExeFromDefines(): string =
+  let env = getEnv("GENNY_PYTHON")
+  if env.len > 0:
+    return env
+  for token in querySetting(commandLine).splitWhitespace():
+    for prefix in ["-d:gennyPythonExe=", "--define:gennyPythonExe:"]:
+      if token.startsWith(prefix):
+        return token[prefix.len .. ^1]
+  "python"
+
+proc pyConfig(): Table[string, string] =
+  let exe = pythonExeFromDefines()
+  let script = "import sysconfig, importlib.machinery;" &
+    "keys=['EXT_SUFFIX','INCLUDEPY','LIBDIR','VERSION'];" &
+    "print('\\n'.join(str(sysconfig.get_config_var(k) or '') for k in keys))"
+  let outp = staticExec(quoteShell(exe) & " -c " & quoteShell(script)).splitLines()
+  if outp.len < 4 or outp[0].len == 0 or outp[1].len == 0:
+    error("Unable to discover Python build settings. Set GENNY_PYTHON to the Python executable.")
+  result["EXT_SUFFIX"] = outp[0]
+  result["INCLUDEPY"] = outp[1]
+  result["LIBDIR"] = outp[2]
+  result["VERSION"] = outp[3]
+
+proc toUnixPath(s: string): string =
+  s.replace("\\", "/")
+
+proc writePyNative*(dir, lib: string): NimNode =
+  createDir(dir)
+  let cfg = pyConfig()
+  let cPath = (dir / (toSnakeCase(lib) & "_native.c")).toUnixPath
+  var finalTypeBlocks = cTypeBlocks
+  for typeName, entries in typeMethods:
+    finalTypeBlocks = finalTypeBlocks.replace(
+      &"/* GENNY_METHODS_{cIdent(typeName)} */\n",
+      entries
+    )
+
+  var code = ""
+  code.add "#define PY_SSIZE_T_CLEAN\n"
+  code.add "#include <Python.h>\n"
+  code.add "#include <stdint.h>\n"
+  code.add "#include <stdarg.h>\n"
+  code.add "#include <stddef.h>\n"
+  code.add "#include <string.h>\n\n"
+  code.add "extern void NimMain(void);\n"
+  code.add "static PyObject *GennyPy_ModuleError = NULL;\n"
+  code.add "static int genny_nim_ready = 0;\n"
+  code.add "static void genny_ensure_nim(void) {\n"
+  code.add "#ifndef _WIN32\n"
+  code.add "  if (!genny_nim_ready) { NimMain(); genny_nim_ready = 1; }\n"
+  code.add "#else\n"
+  code.add "  genny_nim_ready = 1;\n"
+  code.add "#endif\n"
+  code.add "}\n\n"
+  code.add "static int genny_parse_args(const char *func, PyObject *args, PyObject *kwargs, Py_ssize_t nparams, const char **names, Py_ssize_t required, ...) {\n"
+  code.add "  Py_ssize_t nargs = PyTuple_GET_SIZE(args);\n"
+  code.add "  if (nargs > nparams) { PyErr_Format(PyExc_TypeError, \"%s expected at most %zd arguments, got %zd\", func, nparams, nargs); return 0; }\n"
+  code.add "  va_list ap;\n"
+  code.add "  va_start(ap, required);\n"
+  code.add "  for (Py_ssize_t i = 0; i < nparams; ++i) {\n"
+  code.add "    PyObject **slot = va_arg(ap, PyObject **);\n"
+  code.add "    PyObject *kw = (kwargs && names) ? PyDict_GetItemString(kwargs, names[i]) : NULL;\n"
+  code.add "    if (i < nargs && kw != NULL) { va_end(ap); PyErr_Format(PyExc_TypeError, \"%s got multiple values for argument '%s'\", func, names[i]); return 0; }\n"
+  code.add "    *slot = (i < nargs) ? PyTuple_GET_ITEM(args, i) : kw;\n"
+  code.add "    if (*slot == NULL && i < required) { va_end(ap); PyErr_Format(PyExc_TypeError, \"%s missing required argument '%s'\", func, names[i]); return 0; }\n"
+  code.add "  }\n"
+  code.add "  va_end(ap);\n"
+  code.add "  if (kwargs && names) {\n"
+  code.add "    PyObject *key; PyObject *value; Py_ssize_t pos = 0;\n"
+  code.add "    while (PyDict_Next(kwargs, &pos, &key, &value)) {\n"
+  code.add "      const char *k = PyUnicode_AsUTF8(key);\n"
+  code.add "      if (k == NULL) return 0;\n"
+  code.add "      int found = 0;\n"
+  code.add "      for (Py_ssize_t i = 0; i < nparams; ++i) if (strcmp(k, names[i]) == 0) { found = 1; break; }\n"
+  code.add "      if (!found) { PyErr_Format(PyExc_TypeError, \"%s got an unexpected keyword argument '%s'\", func, k); return 0; }\n"
+  code.add "    }\n"
+  code.add "  }\n"
+  code.add "  return 1;\n"
+  code.add "}\n\n"
+  if needsErrorBridge:
+    code.add "extern char $lib_check_error(void);\n"
+    code.add "extern char *$lib_take_error(void);\n"
+    code.add "static char (*pixie_native_check_error)(void) = $lib_check_error;\n"
+    code.add "static char *(*pixie_native_take_error)(void) = $lib_take_error;\n\n"
+  code.add cTypes
+  code.add "\n"
+  code.add cForwardDecls
+  code.add "\n"
+  code.add cProtos
+  code.add "\n"
+  code.add finalTypeBlocks
+  code.add "\n"
+  code.add cWrappers
+  code.add "static PyMethodDef GennyPy_ModuleMethods[] = {\n"
+  code.add cModuleMethods
+  code.add "  {NULL, NULL, 0, NULL}\n};\n\n"
+  code.add "static struct PyModuleDef GennyPy_Module = {\n"
+  code.add "  PyModuleDef_HEAD_INIT,\n"
+  code.add &"  {cString(toSnakeCase(lib))},\n"
+  code.add "  NULL,\n"
+  code.add "  -1,\n"
+  code.add "  GennyPy_ModuleMethods\n"
+  code.add "};\n\n"
+  code.add "PyMODINIT_FUNC PyInit_$lib(void) {\n"
+  code.add "  genny_ensure_nim();\n"
+  code.add "  PyObject *m = PyModule_Create(&GennyPy_Module);\n"
+  code.add "  if (m == NULL) return NULL;\n"
+  code.add &"  GennyPy_ModuleError = PyErr_NewException({cString(toSnakeCase(lib) & \".\" & lib & \"Error\")}, NULL, NULL);\n"
+  code.add "  if (GennyPy_ModuleError == NULL) return NULL;\n"
+  code.add "  Py_INCREF(GennyPy_ModuleError);\n"
+  code.add &"  if (PyModule_AddObject(m, {cString(lib & \"Error\")}, GennyPy_ModuleError) < 0) return NULL;\n"
+  code.add cModuleInit
+  code.add "  return m;\n"
+  code.add "}\n"
+
+  code = code.replace("$lib", toSnakeCase(lib)).replace("$Lib", lib)
+  writeFile(cPath, code)
+
+  result = newStmtList()
+  let includeOpt = "-I" & cfg["INCLUDEPY"].toUnixPath
+  result.add quote do:
+    {.passC: `includeOpt`.}
+  when defined(windows):
+    let libDirOpt = "-L" & cfg["LIBDIR"].toUnixPath
+    let pyLibOpt = "-lpython" & cfg["VERSION"]
+    let staticLibGccOpt = "-static-libgcc"
+    result.add quote do:
+      {.passL: `libDirOpt`.}
+      {.passL: `pyLibOpt`.}
+      {.passL: `staticLibGccOpt`.}
+  elif defined(macosx):
+    let dynLookup = "-undefined dynamic_lookup"
+    result.add quote do:
+      {.passL: `dynLookup`.}
+  let compilePath = cPath
+  result.add quote do:
+    {.compile: `compilePath`.}

--- a/tests/bench_python.py
+++ b/tests/bench_python.py
@@ -1,0 +1,43 @@
+"""Small non-gating ctypes call overhead benchmark."""
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent / "generated"
+CTYPES_PATH = ROOT / "test.py"
+
+
+def load_ctypes():
+    if not CTYPES_PATH.exists():
+        raise SystemExit(f"Missing ctypes wrapper: {CTYPES_PATH}")
+
+    spec = importlib.util.spec_from_file_location("test", CTYPES_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["test"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def bench(label, func, iterations):
+    for _ in range(1000):
+        func(42)
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        func(42)
+    elapsed = time.perf_counter() - start
+    print(f"{label}: {elapsed * 1e9 / iterations:.1f} ns/call")
+
+
+def main():
+    iterations = 200_000
+    ctypes_mod = load_ctypes()
+    bench("ctypes", ctypes_mod.simple_call, iterations)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bench_python_native.py
+++ b/tests/bench_python_native.py
@@ -1,0 +1,44 @@
+"""Small non-gating native CPython extension call overhead benchmark."""
+
+import importlib.util
+import sys
+import sysconfig
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent / "generated"
+NATIVE_PATH = ROOT / ("test" + sysconfig.get_config_var("EXT_SUFFIX"))
+
+
+def load_native():
+    if not NATIVE_PATH.exists():
+        raise SystemExit(f"Missing native extension: {NATIVE_PATH}")
+
+    spec = importlib.util.spec_from_file_location("test", NATIVE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["test"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def bench(label, func, iterations):
+    for _ in range(1000):
+        func(42)
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        func(42)
+    elapsed = time.perf_counter() - start
+    print(f"{label}: {elapsed * 1e9 / iterations:.1f} ns/call")
+
+
+def main():
+    iterations = 200_000
+    native = load_native()
+    bench("native", native.simple_call, iterations)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_python_native.py
+++ b/tests/test_python_native.py
@@ -1,0 +1,104 @@
+"""Test native CPython bindings."""
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent / "generated"))
+import test  # noqa: E402
+
+
+def test_module_values():
+    assert test.simple_call(42) == 42
+    assert test.simple_call(0) == 0
+
+    assert test.SIMPLE_CONST == 123
+    assert test.FIRST == 0
+    assert test.SECOND == 1
+    assert test.THIRD == 2
+    assert test.SimpleEnum is int
+
+
+def test_value_objects():
+    obj = test.SimpleObj(10, 20, True)
+    assert obj.simple_a == 10
+    assert obj.simple_b == 20
+    assert obj.simple_c is True
+
+    obj.simple_a = 11
+    obj.simple_b = 21
+    obj.simple_c = False
+    assert obj == test.SimpleObj(11, 21, False)
+    assert obj != test.SimpleObj(12, 21, False)
+
+
+def test_ref_object_fields_and_methods():
+    ref_obj = test.SimpleRefObj()
+    assert bool(ref_obj)
+
+    ref_obj.simple_ref_a = 100
+    ref_obj.simple_ref_b = 50
+    assert ref_obj.simple_ref_a == 100
+    assert ref_obj.simple_ref_b == 50
+    assert ref_obj.doit() is None
+
+
+def test_seq_int():
+    seq_int = test.SeqInt()
+    seq_int.append(1)
+    seq_int.add(2)
+    seq_int.append(3)
+
+    assert len(seq_int) == 3
+    assert list(seq_int) == [1, 2, 3]
+
+    seq_int[1] = 20
+    assert seq_int[1] == 20
+
+    del seq_int[0]
+    assert list(seq_int) == [20, 3]
+
+    seq_int.clear()
+    assert len(seq_int) == 0
+
+
+def test_seq_string_return():
+    datas = test.get_datas()
+    assert isinstance(datas, test.SeqString)
+    assert len(datas) == 3
+    assert list(datas) == ["a", "b", "c"]
+
+
+def test_bound_seq_field():
+    ref_obj = test.RefObjWithSeq()
+    data = ref_obj.data
+    data.append(5)
+    data.add(6)
+
+    assert len(data) == 2
+    assert list(ref_obj.data) == [5, 6]
+
+    data[0] = 7
+    assert list(ref_obj.data) == [7, 6]
+
+    del data[0]
+    assert list(ref_obj.data) == [6]
+
+    data.clear()
+    assert len(ref_obj.data) == 0
+
+
+def test_value_object_methods():
+    obj = test.SimpleObjWithProc(1, 2, True)
+    assert obj.extra_proc() is None
+
+
+def main():
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("All native Python tests passed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- Added a new `-d:gennyPythonNative` backend that generates a CPython extension source and builds it into the Nim `--app:lib` output.
- Kept the existing `-d:gennyPython` ctypes backend intact, while teaching shared Nim/Python backend type handling about `openArray[T]` and `sink[T]`.
- Added native Python tests, separate ctypes/native benchmark scripts, and a Python Native CI workflow.
- Added ignores for generated native extension artifacts.

## Why

The Python path can avoid ctypes call overhead by importing a CPython-native extension directly. This backend keeps the current Genny DSL and generated internal Nim ABI, but packages the C/Python wrapper and Nim library code into one importable module.

## Validation

- `nim c --mm:arc --app:lib -d:gennyPython -o:tests\generated\test.dll tests\test.nim`
- `python tests/test_python.py`
- `python tests/bench_python.py` (`ctypes: 432.9 ns/call` locally)
- `nim c --mm:arc --app:lib -d:gennyPythonNative -o:tests\generated\test<EXT_SUFFIX> tests\test.nim`
- `python tests/test_python_native.py` via direct test function runner (`7` tests)
- `python tests/bench_python_native.py` (`native: 162.2 ns/call` locally)
- `nim c --mm:arc --app:lib -d:gennyNim -o:tests\generated\test.dll tests\test.nim`
- `nim c -r --mm:arc tests\test_nim.nim`

## Notes

Pixie was also used locally as a second-stage acceptance test while developing this backend, but this PR only contains the Genny changes.