### PR TITLE
Add Pixie binding coverage

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -10,9 +10,24 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: treeform/setup-nim-action@v6
+    - name: Checkout Pixie
+      uses: actions/checkout@v4
+      with:
+        repository: treeform/pixie
+        path: pixie
+    - name: Move Pixie checkout beside Genny
+      run: rm -rf ../pixie && mv pixie ../pixie
+    - name: Install Pixie dependencies
+      run: cd .. && nimby install -g pixie/pixie.nimble
     - name: Build test DLL
       run: nim c --mm:arc --app:lib -d:gennyC -o:tests/generated/libtest.so tests/test.nim
     - name: Compile C test
       run: gcc -o tests/test_c tests/test_c.c -I tests/generated -L tests/generated -l:libtest.so -Wl,-rpath,'$ORIGIN/generated'
     - name: Run C test
       run: ./tests/test_c
+    - name: Build Pixie bindings
+      run: nim c --mm:arc --app:lib -d:gennyC --path:src --path:../pixie/src -o:../pixie/bindings/generated/libpixie.so ../pixie/bindings/bindings.nim
+    - name: Compile Pixie C test
+      run: gcc -o tests/test_pixie_c tests/test_pixie_c.c -I ../pixie/bindings/generated -L ../pixie/bindings/generated -l:libpixie.so -lm -Wl,-rpath,'$ORIGIN/../../pixie/bindings/generated'
+    - name: Run Pixie C test
+      run: ./tests/test_pixie_c

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run C test
       run: ./tests/test_c
     - name: Build Pixie bindings
-      run: nim c --mm:arc --app:lib -d:gennyC --path:src --path:../pixie/src -o:../pixie/bindings/generated/libpixie.so ../pixie/bindings/bindings.nim
+      run: cd ../pixie && nim c --mm:arc --app:lib -d:gennyC --path:../genny/src --path:src -o:bindings/generated/libpixie.so bindings/bindings.nim
     - name: Compile Pixie C test
       run: gcc -o tests/test_pixie_c tests/test_pixie_c.c -I ../pixie/bindings/generated -L ../pixie/bindings/generated -l:libpixie.so -lm -Wl,-rpath,'$ORIGIN/../../pixie/bindings/generated'
     - name: Run Pixie C test

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: treeform/pixie
+        ref: pixie-binding-abi-fixes
         path: pixie
     - name: Move Pixie checkout beside Genny
       run: rm -rf ../pixie && mv pixie ../pixie

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run C++ test
       run: ./tests/test_cpp
     - name: Build Pixie bindings
-      run: nim c --mm:arc --app:lib -d:gennyCpp --path:src --path:../pixie/src -o:../pixie/bindings/generated/libpixie.so ../pixie/bindings/bindings.nim
+      run: cd ../pixie && nim c --mm:arc --app:lib -d:gennyCpp --path:../genny/src --path:src -o:bindings/generated/libpixie.so bindings/bindings.nim
     - name: Compile Pixie C++ test
       run: g++ -o tests/test_pixie_cpp tests/test_pixie_cpp.cpp -I ../pixie/bindings/generated -L ../pixie/bindings/generated -l:libpixie.so -Wl,-rpath,'$ORIGIN/../../pixie/bindings/generated'
     - name: Run Pixie C++ test

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -10,9 +10,24 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: treeform/setup-nim-action@v6
+    - name: Checkout Pixie
+      uses: actions/checkout@v4
+      with:
+        repository: treeform/pixie
+        path: pixie
+    - name: Move Pixie checkout beside Genny
+      run: rm -rf ../pixie && mv pixie ../pixie
+    - name: Install Pixie dependencies
+      run: cd .. && nimby install -g pixie/pixie.nimble
     - name: Build test DLL
       run: nim c --mm:arc --app:lib -d:gennyCpp -o:tests/generated/libtest.so tests/test.nim
     - name: Compile C++ test
       run: g++ -o tests/test_cpp tests/test_cpp.cpp -I tests/generated -L tests/generated -l:libtest.so -Wl,-rpath,'$ORIGIN/generated'
     - name: Run C++ test
       run: ./tests/test_cpp
+    - name: Build Pixie bindings
+      run: nim c --mm:arc --app:lib -d:gennyCpp --path:src --path:../pixie/src -o:../pixie/bindings/generated/libpixie.so ../pixie/bindings/bindings.nim
+    - name: Compile Pixie C++ test
+      run: g++ -o tests/test_pixie_cpp tests/test_pixie_cpp.cpp -I ../pixie/bindings/generated -L ../pixie/bindings/generated -l:libpixie.so -Wl,-rpath,'$ORIGIN/../../pixie/bindings/generated'
+    - name: Run Pixie C++ test
+      run: ./tests/test_pixie_cpp

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: treeform/pixie
+        ref: pixie-binding-abi-fixes
         path: pixie
     - name: Move Pixie checkout beside Genny
       run: rm -rf ../pixie && mv pixie ../pixie

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -28,7 +28,7 @@ jobs:
         nim c --mm:arc -o:tests/generated/test_nim tests/test_nim.nim
         cd tests/generated && LD_LIBRARY_PATH=. ./test_nim
     - name: Build Pixie bindings
-      run: nim c --mm:arc --app:lib -d:gennyNim --path:src --path:../pixie/src -o:../pixie/bindings/generated/libpixie.so ../pixie/bindings/bindings.nim
+      run: cd ../pixie && nim c --mm:arc --app:lib -d:gennyNim --path:../genny/src --path:src -o:bindings/generated/libpixie.so bindings/bindings.nim
     - name: Run Pixie Nim-C-Nim sandwich test
       run: |
         nim c --mm:arc -o:tests/test_pixie_nim tests/test_pixie_nim.nim

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -10,6 +10,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: treeform/setup-nim-action@v6
+    - name: Checkout Pixie
+      uses: actions/checkout@v4
+      with:
+        repository: treeform/pixie
+        path: pixie
+    - name: Move Pixie checkout beside Genny
+      run: rm -rf ../pixie && mv pixie ../pixie
+    - name: Install Pixie dependencies
+      run: cd .. && nimby install -g pixie/pixie.nimble
     - name: Install dependencies
       run: nimble install -y bumpy chroma vmath
     - name: Build test DLL
@@ -18,3 +27,9 @@ jobs:
       run: |
         nim c --mm:arc -o:tests/generated/test_nim tests/test_nim.nim
         cd tests/generated && LD_LIBRARY_PATH=. ./test_nim
+    - name: Build Pixie bindings
+      run: nim c --mm:arc --app:lib -d:gennyNim --path:src --path:../pixie/src -o:../pixie/bindings/generated/libpixie.so ../pixie/bindings/bindings.nim
+    - name: Run Pixie Nim-C-Nim sandwich test
+      run: |
+        nim c --mm:arc -o:tests/test_pixie_nim tests/test_pixie_nim.nim
+        PIXIE_ROOT=../pixie LD_LIBRARY_PATH=$PWD/../pixie/bindings/generated ./tests/test_pixie_nim

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: treeform/pixie
+        ref: pixie-binding-abi-fixes
         path: pixie
     - name: Move Pixie checkout beside Genny
       run: rm -rf ../pixie && mv pixie ../pixie

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -15,6 +15,15 @@ jobs:
         node-version: '20'
     - name: Setup Nim
       uses: treeform/setup-nim-action@v6
+    - name: Checkout Pixie
+      uses: actions/checkout@v4
+      with:
+        repository: treeform/pixie
+        path: pixie
+    - name: Move Pixie checkout beside Genny
+      run: rm -rf ../pixie && mv pixie ../pixie
+    - name: Install Pixie dependencies
+      run: cd .. && nimby install -g pixie/pixie.nimble
     - name: Build shared library
       run: nim c --mm:arc --app:lib -d:gennyNode -o:tests/generated/libtest.so tests/test.nim
     - name: Install koffi
@@ -23,3 +32,7 @@ jobs:
     - name: Run tests
       working-directory: tests
       run: node test_node.js
+    - name: Build Pixie bindings
+      run: nim c --mm:arc --app:lib -d:gennyNode --path:src --path:../pixie/src -o:../pixie/bindings/generated/libpixie.so ../pixie/bindings/bindings.nim
+    - name: Run Pixie Node tests
+      run: NODE_PATH=$PWD/tests/node_modules PIXIE_ROOT=../pixie PIXIE_BINDINGS_DIR=../pixie/bindings/generated LD_LIBRARY_PATH=$PWD/../pixie/bindings/generated node tests/test_pixie_node.js

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: treeform/pixie
+        ref: pixie-binding-abi-fixes
         path: pixie
     - name: Move Pixie checkout beside Genny
       run: rm -rf ../pixie && mv pixie ../pixie

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -33,6 +33,6 @@ jobs:
       working-directory: tests
       run: node test_node.js
     - name: Build Pixie bindings
-      run: nim c --mm:arc --app:lib -d:gennyNode --path:src --path:../pixie/src -o:../pixie/bindings/generated/libpixie.so ../pixie/bindings/bindings.nim
+      run: cd ../pixie && nim c --mm:arc --app:lib -d:gennyNode --path:../genny/src --path:src -o:bindings/generated/libpixie.so bindings/bindings.nim
     - name: Run Pixie Node tests
       run: NODE_PATH=$PWD/tests/node_modules PIXIE_ROOT=../pixie PIXIE_BINDINGS_DIR=../pixie/bindings/generated LD_LIBRARY_PATH=$PWD/../pixie/bindings/generated node tests/test_pixie_node.js

--- a/.github/workflows/python-native.yml
+++ b/.github/workflows/python-native.yml
@@ -31,7 +31,8 @@ jobs:
     - name: Build Pixie native extension
       run: |
         EXT_SUFFIX="$(python -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')"
-        nim c --mm:arc --app:lib -d:gennyPythonNative --path:src --path:../pixie/src -o:../pixie/bindings/generated/pixie${EXT_SUFFIX} ../pixie/bindings/bindings.nim
+        cd ../pixie
+        nim c --mm:arc --app:lib -d:gennyPythonNative --path:../genny/src --path:src -o:bindings/generated/pixie${EXT_SUFFIX} bindings/bindings.nim
     - name: Run Pixie native Python test
       run: PIXIE_ROOT=../pixie PIXIE_BINDINGS_DIR=../pixie/bindings/generated LD_LIBRARY_PATH=$PWD/../pixie/bindings/generated python tests/test_pixie_python_native.py
     - name: Run non-gating benchmark

--- a/.github/workflows/python-native.yml
+++ b/.github/workflows/python-native.yml
@@ -10,6 +10,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: treeform/setup-nim-action@v6
+    - name: Checkout Pixie
+      uses: actions/checkout@v4
+      with:
+        repository: treeform/pixie
+        path: pixie
+    - name: Move Pixie checkout beside Genny
+      run: rm -rf ../pixie && mv pixie ../pixie
+    - name: Install Pixie dependencies
+      run: cd .. && nimby install -g pixie/pixie.nimble
     - uses: actions/setup-python@v5
       with:
         python-version: '3.12'
@@ -19,6 +28,12 @@ jobs:
         nim c --mm:arc --app:lib -d:gennyPythonNative -o:tests/generated/test${EXT_SUFFIX} tests/test.nim
     - name: Run native Python test
       run: python tests/test_python_native.py
+    - name: Build Pixie native extension
+      run: |
+        EXT_SUFFIX="$(python -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')"
+        nim c --mm:arc --app:lib -d:gennyPythonNative --path:src --path:../pixie/src -o:../pixie/bindings/generated/pixie${EXT_SUFFIX} ../pixie/bindings/bindings.nim
+    - name: Run Pixie native Python test
+      run: PIXIE_ROOT=../pixie PIXIE_BINDINGS_DIR=../pixie/bindings/generated LD_LIBRARY_PATH=$PWD/../pixie/bindings/generated python tests/test_pixie_python_native.py
     - name: Run non-gating benchmark
       continue-on-error: true
       run: python tests/bench_python_native.py

--- a/.github/workflows/python-native.yml
+++ b/.github/workflows/python-native.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: treeform/pixie
+        ref: pixie-binding-abi-fixes
         path: pixie
     - name: Move Pixie checkout beside Genny
       run: rm -rf ../pixie && mv pixie ../pixie

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,6 +10,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: treeform/setup-nim-action@v6
+    - name: Checkout Pixie
+      uses: actions/checkout@v4
+      with:
+        repository: treeform/pixie
+        path: pixie
+    - name: Move Pixie checkout beside Genny
+      run: rm -rf ../pixie && mv pixie ../pixie
+    - name: Install Pixie dependencies
+      run: cd .. && nimby install -g pixie/pixie.nimble
     - uses: actions/setup-python@v5
       with:
         python-version: '3.12'
@@ -17,6 +26,10 @@ jobs:
       run: nim c --mm:arc --app:lib -d:gennyPython -o:tests/generated/libtest.so tests/test.nim
     - name: Run Python test
       run: python tests/test_python.py
+    - name: Build Pixie bindings
+      run: nim c --mm:arc --app:lib -d:gennyPython --path:src --path:../pixie/src -o:../pixie/bindings/generated/libpixie.so ../pixie/bindings/bindings.nim
+    - name: Run Pixie Python test
+      run: PIXIE_ROOT=../pixie PIXIE_BINDINGS_DIR=../pixie/bindings/generated LD_LIBRARY_PATH=$PWD/../pixie/bindings/generated python tests/test_pixie_python.py
     - name: Run non-gating benchmark
       continue-on-error: true
       run: python tests/bench_python.py

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Run Python test
       run: python tests/test_python.py
     - name: Build Pixie bindings
-      run: nim c --mm:arc --app:lib -d:gennyPython --path:src --path:../pixie/src -o:../pixie/bindings/generated/libpixie.so ../pixie/bindings/bindings.nim
+      run: cd ../pixie && nim c --mm:arc --app:lib -d:gennyPython --path:../genny/src --path:src -o:bindings/generated/libpixie.so bindings/bindings.nim
     - name: Run Pixie Python test
       run: PIXIE_ROOT=../pixie PIXIE_BINDINGS_DIR=../pixie/bindings/generated LD_LIBRARY_PATH=$PWD/../pixie/bindings/generated python tests/test_pixie_python.py
     - name: Run non-gating benchmark

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: treeform/pixie
+        ref: pixie-binding-abi-fixes
         path: pixie
     - name: Move Pixie checkout beside Genny
       run: rm -rf ../pixie && mv pixie ../pixie

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -41,5 +41,6 @@ jobs:
     - name: Run Pixie Zig test
       working-directory: tests
       run: |
+        cp ../../pixie/bindings/generated/pixie.zig generated/pixie.zig
         zig build-exe test_pixie_zig.zig -lc -L../../pixie/bindings/generated -lpixie
         LD_LIBRARY_PATH=$PWD/../../pixie/bindings/generated ./test_pixie_zig

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -37,7 +37,7 @@ jobs:
         zig build-exe test_zig.zig -lc -Lgenerated -ltest
         LD_LIBRARY_PATH=$PWD/generated ./test_zig
     - name: Build Pixie bindings
-      run: nim c --mm:arc --app:lib -d:gennyZig --path:src --path:../pixie/src -o:../pixie/bindings/generated/libpixie.so ../pixie/bindings/bindings.nim
+      run: cd ../pixie && nim c --mm:arc --app:lib -d:gennyZig --path:../genny/src --path:src -o:bindings/generated/libpixie.so bindings/bindings.nim
     - name: Run Pixie Zig test
       working-directory: tests
       run: |

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: treeform/pixie
+        ref: pixie-binding-abi-fixes
         path: pixie
     - name: Move Pixie checkout beside Genny
       run: rm -rf ../pixie && mv pixie ../pixie

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -10,6 +10,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: treeform/setup-nim-action@v6
+    - name: Checkout Pixie
+      uses: actions/checkout@v4
+      with:
+        repository: treeform/pixie
+        path: pixie
+    - name: Move Pixie checkout beside Genny
+      run: rm -rf ../pixie && mv pixie ../pixie
+    - name: Install Pixie dependencies
+      run: cd .. && nimby install -g pixie/pixie.nimble
     - uses: goto-bus-stop/setup-zig@v2
       with:
         version: 0.13.0
@@ -27,3 +36,10 @@ jobs:
       run: |
         zig build-exe test_zig.zig -lc -Lgenerated -ltest
         LD_LIBRARY_PATH=$PWD/generated ./test_zig
+    - name: Build Pixie bindings
+      run: nim c --mm:arc --app:lib -d:gennyZig --path:src --path:../pixie/src -o:../pixie/bindings/generated/libpixie.so ../pixie/bindings/bindings.nim
+    - name: Run Pixie Zig test
+      working-directory: tests
+      run: |
+        zig build-exe test_pixie_zig.zig -lc -L../../pixie/bindings/generated -lpixie
+        LD_LIBRARY_PATH=$PWD/../../pixie/bindings/generated ./test_pixie_zig

--- a/src/genny/internal.nim
+++ b/src/genny/internal.nim
@@ -91,12 +91,14 @@ proc exportObjectInternal*(sym: NimNode, constructor: NimNode) =
 
     internal.add &"proc $lib_{objNameSnaked}*("
     for param in constructorType[0][1 .. ^1]:
-      internal.add &"{param[0].repr.split('`')[0]}: {param[1].repr}, "
+      internal.add &"{param[0].repr.split('`')[0]}: {exportTypeNim(param[1])}, "
     internal.removeSuffix ", "
     internal.add &"): {objName} {exportProcPragmas} =\n"
     internal.add &"  {constructor.repr}("
     for param in constructorType[0][1 .. ^1]:
-      internal.add &"{param[0].repr.split('`')[0]}, "
+      let paramName = param[0].repr.split('`')[0]
+      internal.add convertImportExprNim(paramName, param[1])
+      internal.add ", "
     internal.removeSuffix ", "
     internal.add ")\n"
     internal.add "\n"
@@ -113,7 +115,10 @@ proc exportObjectInternal*(sym: NimNode, constructor: NimNode) =
     for fieldSym in objType[2]:
       let
         fieldName = fieldSym.repr
-      internal.add &"  result.{toSnakeCase(fieldName)} = {toSnakeCase(fieldName)}\n"
+        fieldType = fieldSym.getTypeInst()
+      internal.add &"  result.{toSnakeCase(fieldName)} = "
+      internal.add convertImportExprNim(toSnakeCase(fieldName), fieldType)
+      internal.add "\n"
     internal.add "\n"
 
   internal.add &"proc $lib_{objNameSnaked}_eq*(a, b: {objName}): bool {exportProcPragmas}=\n"
@@ -174,19 +179,25 @@ proc exportRefObjectInternal*(
       internal.add &"  {objNameSnaked}.{fieldName}.len\n"
       internal.add "\n"
 
-      internal.add &"proc {prefix}_add*({objNameSnaked}: {objName}, v: {fieldType[1].repr})"
+      internal.add &"proc {prefix}_add*({objNameSnaked}: {objName}, v: {exportTypeNim(fieldType[1])})"
       internal.add &" {exportProcPragmas} =\n"
-      internal.add &"  {objNameSnaked}.{fieldName}.add(v)\n"
+      internal.add &"  {objNameSnaked}.{fieldName}.add("
+      internal.add convertImportExprNim("v", fieldType[1])
+      internal.add ")\n"
       internal.add "\n"
 
-      internal.add &"proc {prefix}_get*({objNameSnaked}: {objName}, i: int): {fieldType[1].repr}"
+      internal.add &"proc {prefix}_get*({objNameSnaked}: {objName}, i: int): {exportTypeNim(fieldType[1])}"
       internal.add &" {exportProcPragmas} =\n"
-      internal.add &"  {objNameSnaked}.{fieldName}[i]\n"
+      internal.add "  "
+      internal.add convertExportExprNim(&"{objNameSnaked}.{fieldName}[i]", fieldType[1])
+      internal.add "\n"
       internal.add "\n"
 
-      internal.add &"proc {prefix}_set*({objNameSnaked}: {objName}, i: int, v: {fieldType[1].repr})"
+      internal.add &"proc {prefix}_set*({objNameSnaked}: {objName}, i: int, v: {exportTypeNim(fieldType[1])})"
       internal.add &" {exportProcPragmas} =\n"
-      internal.add &"  {objNameSnaked}.{fieldName}[i] = v\n"
+      internal.add &"  {objNameSnaked}.{fieldName}[i] = "
+      internal.add convertImportExprNim("v", fieldType[1])
+      internal.add "\n"
       internal.add "\n"
 
       internal.add &"proc {prefix}_delete*({objNameSnaked}: {objName}, i: int)"

--- a/src/genny/internal.nim
+++ b/src/genny/internal.nim
@@ -26,6 +26,9 @@ proc exportProcInternal*(
     procReturn = procType[0][0]
     procRaises = sym.raises()
     procReturnsSeq = procReturn.kind == nnkBracketExpr
+    shouldGcRefResult = gcRefResult or procReturnsSeq or (
+      procReturn.kind != nnkEmpty and procReturn.isRefObjectLike
+    )
 
   var apiProcName = &"$lib_"
   if owner != nil:
@@ -50,29 +53,31 @@ proc exportProcInternal*(
     internal.add "  try:\n  "
   if procRaises and procReturn.kind != nnkEmpty:
     internal.add "  result = "
-  elif gcRefResult:
+  elif shouldGcRefResult:
     internal.add "  result = "
   else:
     internal.add "  "
-  if procReturnsSeq:
-    internal.add &"{procReturn.getSeqName()}(s: "
-  internal.add &"{procName}("
+  var callExpr = &"{procName}("
   for param in procParams:
     for i in 0 .. param.len - 3:
-      internal.add &"{toSnakeCase(param[i].repr)}"
-      internal.add &"{convertImportToNim(param[^2])}, "
-  internal.removeSuffix ", "
-  internal.add ")"
+      callExpr.add convertImportExprNim(toSnakeCase(param[i].repr), param[^2])
+      callExpr.add ", "
+  callExpr.removeSuffix ", "
+  callExpr.add ")"
+
   if procReturnsSeq:
-    internal.add ")"
-  if procReturn.kind != nnkEmpty:
-    internal.add convertExportFromNim(procReturn)
+    internal.add &"{procReturn.getSeqName()}(s: {callExpr})"
+  elif procReturn.kind != nnkEmpty:
+    internal.add convertExportExprNim(callExpr, procReturn)
+  else:
+    internal.add callExpr
   if procRaises:
     internal.add "\n"
     internal.add "  except $LibError as e:\n"
     internal.add "    lastError = e"
-  if gcRefResult:
-    internal.add "\n  GC_ref(result)"
+  if shouldGcRefResult:
+    internal.add "\n  if result != nil:"
+    internal.add "\n    GC_ref(result)"
   internal.add "\n"
   internal.add "\n"
 
@@ -147,8 +152,8 @@ proc exportRefObjectInternal*(
       internal.add &"$lib_{objNameSnaked}_get_{fieldNameSnaked}*"
       internal.add &"({objNameSnaked}: {objName}): {exportTypeNim(fieldType)}"
       internal.add &" {exportProcPragmas} =\n"
-      internal.add &"  {objNameSnaked}.{fieldName}"
-      internal.add convertExportFromNim(fieldType)
+      internal.add "  "
+      internal.add convertExportExprNim(&"{objNameSnaked}.{fieldName}", fieldType)
       internal.add "\n"
       internal.add "\n"
 
@@ -157,8 +162,8 @@ proc exportRefObjectInternal*(
       internal.add &"({objNameSnaked}: {objName}, "
       internal.add &"{fieldName}: {exportTypeNim(fieldType)})"
       internal.add &" {exportProcPragmas} =\n"
-      internal.add &"  {objNameSnaked}.{fieldName} = {fieldName}"
-      internal.add convertImportToNim(fieldType)
+      internal.add &"  {objNameSnaked}.{fieldName} = "
+      internal.add convertImportExprNim(fieldName, fieldType)
       internal.add "\n"
       internal.add "\n"
     else:
@@ -219,19 +224,25 @@ proc generateSeqs(sym: NimNode) =
   internal.add &"proc $lib_{seqNameSnaked}_add*(s: {seqName}, v: {exportTypeNim(sym[1])})"
   internal.add &" {exportProcPragmas}"
   internal.add " =\n"
-  internal.add &"  s.s.add(v{convertImportToNim(sym[1])})\n"
+  internal.add "  s.s.add("
+  internal.add convertImportExprNim("v", sym[1])
+  internal.add ")\n"
   internal.add "\n"
 
   internal.add &"proc $lib_{seqNameSnaked}_get*(s: {seqName}, i: int): {exportTypeNim(sym[1])}"
   internal.add &" {exportProcPragmas}"
   internal.add " =\n"
-  internal.add &"  s.s[i]{convertExportFromNim(sym[1])}\n"
+  internal.add "  "
+  internal.add convertExportExprNim("s.s[i]", sym[1])
+  internal.add "\n"
   internal.add "\n"
 
   internal.add &"proc $lib_{seqNameSnaked}_set*(s: {seqName}, i: int, v: {exportTypeNim(sym[1])})"
   internal.add &" {exportProcPragmas}"
   internal.add " =\n"
-  internal.add &"  s.s[i] = v{convertImportToNim(sym[1])}\n"
+  internal.add "  s.s[i] = "
+  internal.add convertImportExprNim("v", sym[1])
+  internal.add "\n"
   internal.add "\n"
 
   internal.add &"proc $lib_{seqNameSnaked}_delete*(s: {seqName}, i: int)"

--- a/src/genny/languages/c.nim
+++ b/src/genny/languages/c.nim
@@ -6,20 +6,31 @@ var
   types {.compiletime.}: string
   procs {.compiletime.}: string
 
+proc stripSink(sym: NimNode): NimNode =
+  if sym.kind == nnkBracketExpr and sym[0].repr == "sink":
+    sym[1]
+  else:
+    sym
+
+proc isSeqLike(sym: NimNode): bool =
+  let typ = sym.stripSink
+  typ.kind == nnkBracketExpr and typ[0].repr in ["seq", "openArray"]
+
 proc exportTypeC(sym: NimNode): string =
-  if sym.kind == nnkBracketExpr:
-    if sym[0].repr == "array":
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if typ[0].repr == "array":
       let
-        entryCount = sym[1].repr
-        entryType = exportTypeC(sym[2])
+        entryCount = typ[1].repr
+        entryType = exportTypeC(typ[2])
       result = &"{entryType}[{entryCount}]"
-    elif sym[0].repr == "seq":
-      result = sym.getSeqName()
+    elif typ.isSeqLike:
+      result = typ.getSeqName()
     else:
-      error(&"Unexpected bracket expression {sym[0].repr}[")
+      error(&"Unexpected bracket expression {typ[0].repr}[")
   else:
     result =
-      case sym.repr:
+      case typ.repr:
       of "string": "char*"
       of "bool": "char"
       of "byte": "char"
@@ -42,21 +53,22 @@ proc exportTypeC(sym: NimNode): string =
       of "", "nil": "void"
       of "None": "void"
       else:
-        sym.repr
+        typ.repr
 
 proc exportTypeC(sym: NimNode, name: string): string =
-  if sym.kind == nnkBracketExpr:
-    if sym[0].repr == "array":
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if typ[0].repr == "array":
       let
-        entryCount = sym[1].repr
-        entryType = exportTypeC(sym[2], &"{name}[{entryCount}]")
+        entryCount = typ[1].repr
+        entryType = exportTypeC(typ[2], &"{name}[{entryCount}]")
       result = &"{entryType}"
-    elif sym[0].repr == "seq":
-      result = sym.getSeqName() & " " & name
+    elif typ.isSeqLike:
+      result = typ.getSeqName() & " " & name
     else:
-      error(&"Unexpected bracket expression {sym[0].repr}[")
+      error(&"Unexpected bracket expression {typ[0].repr}[")
   else:
-    result = exportTypeC(sym) & " " & name
+    result = exportTypeC(typ) & " " & name
 
 proc dllProc*(procName: string, args: openarray[string], restype: string) =
   var argStr = ""

--- a/src/genny/languages/cpp.nim
+++ b/src/genny/languages/cpp.nim
@@ -11,20 +11,31 @@ var
 proc unCapitalize(s: string): string =
   s[0].toLowerAscii() & s[1 .. ^1]
 
+proc stripSink(sym: NimNode): NimNode =
+  if sym.kind == nnkBracketExpr and sym[0].repr == "sink":
+    sym[1]
+  else:
+    sym
+
+proc isSeqLike(sym: NimNode): bool =
+  let typ = sym.stripSink
+  typ.kind == nnkBracketExpr and typ[0].repr in ["seq", "openArray"]
+
 proc exportTypeCpp(sym: NimNode): string =
-  if sym.kind == nnkBracketExpr:
-    if sym[0].repr == "array":
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if typ[0].repr == "array":
       let
-        entryCount = sym[1].repr
-        entryType = exportTypeCpp(sym[2])
+        entryCount = typ[1].repr
+        entryType = exportTypeCpp(typ[2])
       result = &"{entryType}[{entryCount}]"
-    elif sym[0].repr == "seq":
-      result = sym.getSeqName()
+    elif typ.isSeqLike:
+      result = typ.getSeqName()
     else:
-      error(&"Unexpected bracket expression {sym[0].repr}[")
+      error(&"Unexpected bracket expression {typ[0].repr}[")
   else:
     result =
-      case sym.repr:
+      case typ.repr:
       of "string": "const char*"
       of "bool": "bool"
       of "byte": "char"
@@ -47,24 +58,25 @@ proc exportTypeCpp(sym: NimNode): string =
       of "", "nil": "void"
       of "None": "void"
       else:
-        if sym.getType().kind == nnkBracketExpr:
-          sym.repr
+        if typ.getType().kind == nnkBracketExpr:
+          typ.repr
         else:
-          sym.repr
+          typ.repr
 
 proc exportTypeCpp(sym: NimNode, name: string): string =
-  if sym.kind == nnkBracketExpr:
-    if sym[0].repr == "array":
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if typ[0].repr == "array":
       let
-        entryCount = sym[1].repr
-        entryType = exportTypeCpp(sym[2], &"{name}[{entryCount}]")
+        entryCount = typ[1].repr
+        entryType = exportTypeCpp(typ[2], &"{name}[{entryCount}]")
       result = &"{entryType}"
-    elif sym[0].repr == "seq":
-      result = sym.getSeqName() & " " & name
+    elif typ.isSeqLike:
+      result = typ.getSeqName() & " " & name
     else:
-      error(&"Unexpected bracket expression {sym[0].repr}[")
+      error(&"Unexpected bracket expression {typ[0].repr}[")
   else:
-    result = exportTypeCpp(sym) & " " & name
+    result = exportTypeCpp(typ) & " " & name
 
 proc dllProc*(procName: string, args: openarray[string], restype: string) =
   var argStr = ""

--- a/src/genny/languages/cpp.nim
+++ b/src/genny/languages/cpp.nim
@@ -21,13 +21,16 @@ proc isSeqLike(sym: NimNode): bool =
   let typ = sym.stripSink
   typ.kind == nnkBracketExpr and typ[0].repr in ["seq", "openArray"]
 
-proc exportTypeCpp(sym: NimNode): string =
+proc isRuneType(sym: NimNode): bool =
+  sym.stripSink.repr == "Rune"
+
+proc exportTypeCpp(sym: NimNode, abi = false): string =
   let typ = sym.stripSink
   if typ.kind == nnkBracketExpr:
     if typ[0].repr == "array":
       let
         entryCount = typ[1].repr
-        entryType = exportTypeCpp(typ[2])
+        entryType = exportTypeCpp(typ[2], abi)
       result = &"{entryType}[{entryCount}]"
     elif typ.isSeqLike:
       result = typ.getSeqName()
@@ -52,7 +55,8 @@ proc exportTypeCpp(sym: NimNode): string =
       of "float32": "float"
       of "float64": "double"
       of "float": "double"
-      of "Rune": "int32_t"
+      of "Rune":
+        if abi: "int32_t" else: "char32_t"
       of "Vec2": "Vector2"
       of "Mat3": "Matrix3"
       of "", "nil": "void"
@@ -63,20 +67,38 @@ proc exportTypeCpp(sym: NimNode): string =
         else:
           typ.repr
 
-proc exportTypeCpp(sym: NimNode, name: string): string =
+proc exportTypeCppAbi(sym: NimNode): string =
+  exportTypeCpp(sym, abi = true)
+
+proc exportTypeCpp(sym: NimNode, name: string, abi = false): string =
   let typ = sym.stripSink
   if typ.kind == nnkBracketExpr:
     if typ[0].repr == "array":
       let
         entryCount = typ[1].repr
-        entryType = exportTypeCpp(typ[2], &"{name}[{entryCount}]")
+        entryType = exportTypeCpp(typ[2], &"{name}[{entryCount}]", abi)
       result = &"{entryType}"
     elif typ.isSeqLike:
       result = typ.getSeqName() & " " & name
     else:
       error(&"Unexpected bracket expression {typ[0].repr}[")
   else:
-    result = exportTypeCpp(typ) & " " & name
+    result = exportTypeCpp(typ, abi) & " " & name
+
+proc exportTypeCppAbi(sym: NimNode, name: string): string =
+  exportTypeCpp(sym, name, abi = true)
+
+proc cppArgValue(argType: NimNode, argName: string): string =
+  if argType.isRuneType:
+    &"static_cast<int32_t>({argName})"
+  else:
+    argName
+
+proc cppReturnValue(returnType: NimNode, call: string): string =
+  if returnType.isRuneType:
+    &"static_cast<char32_t>({call})"
+  else:
+    call
 
 proc dllProc*(procName: string, args: openarray[string], restype: string) =
   var argStr = ""
@@ -89,7 +111,7 @@ proc dllProc*(procName: string, args: openarray[string], restype: string) =
 proc dllProc*(procName: string, args: openarray[(NimNode, NimNode)], restype: string) =
   var argsConverted: seq[string]
   for (argName, argType) in args:
-    argsConverted.add exportTypeCpp(argType, toSnakeCase(argName.getName()))
+    argsConverted.add exportTypeCppAbi(argType, toSnakeCase(argName.getName()))
   dllProc(procName, argsConverted, restype)
 
 proc dllProc*(procName: string, restype: string) =
@@ -134,7 +156,7 @@ proc exportProcCpp*(
   var dllParams: seq[(NimNode, NimNode)]
   for param in procParams:
     dllParams.add((param[0], param[1]))
-  dllProc(&"$lib_{apiProcName}", dllParams, exportTypeCpp(procReturn))
+  dllProc(&"$lib_{apiProcName}", dllParams, exportTypeCppAbi(procReturn))
 
   if owner == nil:
     if procReturn.kind != nnkEmpty:
@@ -150,12 +172,14 @@ proc exportProcCpp*(
     members.add "  "
     if procReturn.kind != nnkEmpty:
       members.add "return "
-    members.add &"$lib_{apiProcName}("
+    var call = &"$lib_{apiProcName}("
     for param in procParams:
-      members.add param[0].getName()
-      members.add ", "
-    members.removeSuffix ", "
-    members.add ");\n"
+      call.add cppArgValue(param[1], param[0].getName())
+      call.add ", "
+    call.removeSuffix ", "
+    call.add ")"
+    members.add cppReturnValue(procReturn, call)
+    members.add ";\n"
     members.add "};\n\n"
 
   else:
@@ -193,13 +217,14 @@ proc exportProcCpp*(
       members.add &"  "
     else:
       members.add &"  return "
-    members.add  &"$lib_{apiProcName}("
-    members.add "*this, "
+    var call = &"$lib_{apiProcName}(*this, "
     for param in procParams[1..^1]:
-      members.add param[0].getName()
-      members.add ", "
-    members.removeSuffix ", "
-    members.add ");\n"
+      call.add cppArgValue(param[1], param[0].getName())
+      call.add ", "
+    call.removeSuffix ", "
+    call.add ")"
+    members.add cppReturnValue(procReturn, call)
+    members.add ";\n"
     members.add "};\n\n"
 
 proc exportObjectCpp*(sym: NimNode, constructor: NimNode) =
@@ -218,7 +243,7 @@ proc exportObjectCpp*(sym: NimNode, constructor: NimNode) =
     procs.add &"{objName} $lib_{toSnakeCase(objName)}("
     for identDefs in sym.getImpl()[2][2]:
       for property in identDefs[0 .. ^3]:
-        procs.add &"{exportTypeCpp(identDefs[^2], toSnakeCase(property[1].repr))}, "
+        procs.add &"{exportTypeCppAbi(identDefs[^2], toSnakeCase(property[1].repr))}, "
     procs.removeSuffix ", "
     procs.add ");\n\n"
 
@@ -234,7 +259,7 @@ proc exportObjectCpp*(sym: NimNode, constructor: NimNode) =
     members.add  &"$lib_{toSnakeCase(objName)}("
     for identDefs in sym.getImpl()[2][2]:
       for property in identDefs[0 .. ^3]:
-        members.add property[1].repr
+        members.add cppArgValue(identDefs[^2], property[1].repr)
         members.add ", "
     members.removeSuffix ", "
     members.add ");\n"
@@ -253,10 +278,10 @@ proc genRefObject(objName: string) =
 proc genSeqProcs(objName, procPrefix, selfSuffix: string, entryType: NimNode) =
   let objArg = objName & " " & toSnakeCase(objName)
   dllProc(&"{procPrefix}_len", [objArg], "int64_t")
-  dllProc(&"{procPrefix}_get", [objArg, "int64_t index"], exportTypeCpp(entryType))
-  dllProc(&"{procPrefix}_set", [objArg, "int64_t index", exportTypeCpp(entryType, "value")], "void")
+  dllProc(&"{procPrefix}_get", [objArg, "int64_t index"], exportTypeCppAbi(entryType))
+  dllProc(&"{procPrefix}_set", [objArg, "int64_t index", exportTypeCppAbi(entryType, "value")], "void")
   dllProc(&"{procPrefix}_delete", [objArg, "int64_t index"], "void")
-  dllProc(&"{procPrefix}_add", [objArg, exportTypeCpp(entryType, "value")], "void")
+  dllProc(&"{procPrefix}_add", [objArg, exportTypeCppAbi(entryType, "value")], "void")
   dllProc(&"{procPrefix}_clear", [objArg], "void")
 
 proc exportRefObjectCpp*(
@@ -300,7 +325,7 @@ proc exportRefObjectCpp*(
       members.add &"  this->reference = "
       members.add  &"{constructorLibProc}("
       for param in constructorParams:
-        members.add param[0].getName()
+        members.add cppArgValue(param[1], param[0].getName())
         members.add ", "
       members.removeSuffix ", "
       members.add ").reference;\n"
@@ -321,19 +346,21 @@ proc exportRefObjectCpp*(
       let getMemberName = &"get{fieldName.capitalizeAscii}"
       let setMemberName = &"set{fieldName.capitalizeAscii}"
 
-      dllProc(getProcName, [objName & " " & objNameSnaked], exportTypeCpp(fieldType))
-      dllProc(setProcName, [objName & " " & objNameSnaked, exportTypeCpp(fieldType, "value")], exportTypeCpp(nil))
+      dllProc(getProcName, [objName & " " & objNameSnaked], exportTypeCppAbi(fieldType))
+      dllProc(setProcName, [objName & " " & objNameSnaked, exportTypeCppAbi(fieldType, "value")], exportTypeCppAbi(nil))
 
       classes.add &"  {exportTypeCpp(fieldType)} {getMemberName}();\n"
 
       members.add &"{exportTypeCpp(fieldType)} {objName}::{getMemberName}()" & "{\n"
-      members.add &"  return {getProcName}(*this);\n"
+      let getCall = &"{getProcName}(*this)"
+      members.add &"  return {cppReturnValue(fieldType, getCall)};\n"
       members.add "}\n\n"
 
       classes.add &"  void {setMemberName}({exportTypeCpp(fieldType)} value);\n\n"
 
       members.add &"void {objName}::{setMemberName}({exportTypeCpp(fieldType)} value)" & "{\n"
-      members.add &"  {setProcName}(*this, value);\n"
+      let setValue = cppArgValue(fieldType, "value")
+      members.add &"  {setProcName}(*this, {setValue});\n"
       members.add "}\n\n"
 
       # TODO: property

--- a/src/genny/languages/nim.nim
+++ b/src/genny/languages/nim.nim
@@ -275,7 +275,7 @@ proc exportObjectNim*(sym: NimNode, constructor: NimNode) =
   if objName in ["Rect", "Color"]:
     return
 
-  types.add &"type {objName}* = object\n"
+  types.add &"type {objName}* {{.bycopy.}} = object\n"
   for identDefs in sym.getImpl()[2][2]:
     for property in identDefs[0 .. ^3]:
       types.add &"  {property.repr}: {identDefs[^2].repr}\n"

--- a/src/genny/languages/nim.nim
+++ b/src/genny/languages/nim.nim
@@ -23,6 +23,27 @@ proc stripSink(sym: NimNode): NimNode =
   else:
     return sym
 
+proc normalizeValueTypeName(sym: NimNode): string =
+  case sym.repr
+  of "Vec2":
+    "Vector2"
+  of "Mat3":
+    "Matrix3"
+  else:
+    sym.repr
+
+proc typeBody(sym: NimNode): NimNode =
+  let typ = sym.stripSink
+  if typ.kind == nnkSym:
+    let impl = typ.getImpl()
+    if impl.kind == nnkTypeDef:
+      return impl[2]
+  typ
+
+proc isRefObjectLike*(sym: NimNode): bool =
+  let typ = sym.stripSink
+  typ.repr in refObjectNames or typ.typeBody.kind == nnkRefTy
+
 proc exportTypeNim*(sym: NimNode): string =
   ## Returns type for Nim wrapper proc signature.
   let typ = sym.stripSink
@@ -36,7 +57,18 @@ proc exportTypeNim*(sym: NimNode): string =
     elif typ.repr == "Rune":
       return "int32"
     else:
-      return typ.repr
+      return typ.normalizeValueTypeName()
+
+proc exportArgTypeNim(sym: NimNode): string =
+  ## Returns the friendly type for Nim wrapper parameters. Unlike return values,
+  ## string parameters stay as Nim strings and are converted at the C boundary.
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if not typ.isSeqLike:
+      error(&"Unexpected bracket expression {typ[0].repr}[", typ)
+    return typ.getSeqName()
+  else:
+    return typ.normalizeValueTypeName()
 
 proc exportTypeCImport*(sym: NimNode): string =
   ## Returns type for C import declaration. Ref objects become pointer.
@@ -50,10 +82,10 @@ proc exportTypeCImport*(sym: NimNode): string =
       return "cstring"
     elif typ.repr == "Rune":
       return "int32"
-    elif typ.repr in refObjectNames:
+    elif typ.isRefObjectLike:
       return "pointer"
     else:
-      return typ.repr
+      return typ.normalizeValueTypeName()
 
 proc convertExportFromNim*(sym: NimNode): string =
   ## Converts Nim value to C value (used by DLL side).
@@ -70,6 +102,18 @@ proc convertExportFromNim*(sym: NimNode): string =
     else:
       return ""
 
+proc convertExportExprNim*(expr: string, sym: NimNode): string =
+  ## Converts a Nim expression to the ABI-facing value used by generated
+  ## internal exports.
+  let typ = sym.stripSink
+  case typ.repr
+  of "Vec2":
+    return &"cast[Vector2]({expr})"
+  of "Mat3":
+    return &"cast[Matrix3]({expr})"
+  else:
+    return expr & convertExportFromNim(typ)
+
 proc convertToPointer*(sym: NimNode): string =
   ## Converts client-side wrapper to pointer for C call.
   let typ = sym.stripSink
@@ -82,7 +126,7 @@ proc convertToPointer*(sym: NimNode): string =
       return ".cstring"
     elif typ.repr == "Rune":
       return ".int32"
-    elif typ.repr in refObjectNames:
+    elif typ.isRefObjectLike:
       return ".reference"
     else:
       return ""
@@ -100,6 +144,31 @@ proc convertImportToNim*(sym: NimNode): string =
       return ".Rune"
     else:
       return ""
+
+proc convertImportExprNim*(expr: string, sym: NimNode): string =
+  ## Converts an ABI-facing expression to the Nim value expected by the source
+  ## library implementation.
+  let typ = sym.stripSink
+  case typ.repr
+  of "Vec2":
+    return &"cast[Vec2]({expr})"
+  of "Mat3":
+    return &"cast[Mat3]({expr})"
+  else:
+    return expr & convertImportToNim(typ)
+
+proc exportDefaultValueNim(default, sym: NimNode): string =
+  ## Keeps wrapper defaults in the same ABI-facing type family as the generated
+  ## wrapper signature. Some Pixie APIs use vmath defaults like vec2()/mat3()
+  ## while the wrapper exposes ABI-compatible Vector2/Matrix3 value objects.
+  let typ = sym.stripSink
+  case typ.repr
+  of "Vec2":
+    return &"cast[Vector2]({default.repr})"
+  of "Mat3":
+    return &"cast[Matrix3]({default.repr})"
+  else:
+    return default.repr
 
 proc exportConstNim*(sym: NimNode) =
   let impl = sym.getImpl()
@@ -141,7 +210,7 @@ proc exportProcNim*(
 
   # Check if return type is a ref object
   let returnsRefObject = procReturn.kind != nnkEmpty and
-    (procReturn.repr in refObjectNames or procReturn.kind == nnkBracketExpr)
+    (procReturn.isRefObjectLike or procReturn.isSeqLike)
 
   # C import declaration
   procs.add &"proc {apiProcName}("
@@ -170,9 +239,9 @@ proc exportProcNim*(
     if param[^2].kind == nnkBracketExpr or paramType.repr.startsWith("Some"):
       procs.add &"{param[0].repr}: {exportTypeNim(paramType)}, "
     else:
-      procs.add &"{param[0].repr}: {paramType}"
+      procs.add &"{param[0].repr}: {exportArgTypeNim(paramType)}"
       if defaults[i][1].kind != nnkEmpty:
-        procs.add &" = {defaults[i][1].repr}"
+        procs.add &" = {exportDefaultValueNim(defaults[i][1], paramType)}"
       procs.add ", "
   procs.removeSuffix ", "
   procs.add ")"
@@ -203,7 +272,7 @@ proc exportProcNim*(
 proc exportObjectNim*(sym: NimNode, constructor: NimNode) =
   let objName = sym.repr
 
-  if objName in ["Vector2", "Matrix3", "Rect", "Color"]:
+  if objName in ["Rect", "Color"]:
     return
 
   types.add &"type {objName}* = object\n"
@@ -250,7 +319,10 @@ proc genRefObject(objName: string) =
   types.add &"    {apiProcName}(x.reference)\n"
   types.add "\n"
 
-proc genSeqProcs(objName, niceName, procPrefix, refAccessor, entryName: string) =
+proc genSeqProcs(
+  objName, niceName, procPrefix, refAccessor: string,
+  entryType: NimNode
+) =
   ## refAccessor is how to get .reference from the wrapper (e.g. "" for direct, ".parent" for nested)
   let refSuffix = if refAccessor == "": ".reference" else: refAccessor & ".reference"
 
@@ -265,37 +337,43 @@ proc genSeqProcs(objName, niceName, procPrefix, refAccessor, entryName: string) 
   procs.add "\n"
 
   procs.add &"proc {procPrefix}_add"
-  procs.add &"(s: pointer, v: {entryName})"
+  procs.add &"(s: pointer, v: {exportTypeCImport(entryType)})"
   procs.add " {.importc: \""
   procs.add &"{procPrefix}_add"
   procs.add "\", cdecl.}\n"
   procs.add "\n"
 
-  procs.add &"proc add*(s: {niceName}, v: {entryName}) =\n"
-  procs.add &"  {procPrefix}_add(s{refSuffix}, v)\n"
+  procs.add &"proc add*(s: {niceName}, v: {exportArgTypeNim(entryType)}) =\n"
+  procs.add &"  {procPrefix}_add(s{refSuffix}, v{convertToPointer(entryType)})\n"
   procs.add "\n"
 
   procs.add &"proc {procPrefix}_get"
   procs.add &"(s: pointer, i: int)"
-  procs.add &": {entryName}"
+  procs.add &": {exportTypeCImport(entryType)}"
   procs.add " {.importc: \""
   procs.add &"{procPrefix}_get"
   procs.add "\", cdecl.}\n"
   procs.add "\n"
 
-  procs.add &"proc `[]`*(s: {niceName}, i: int): {entryName} =\n"
-  procs.add &"  {procPrefix}_get(s{refSuffix}, i)\n"
+  procs.add &"proc `[]`*(s: {niceName}, i: int): {exportArgTypeNim(entryType)} =\n"
+  if entryType.isRefObjectLike:
+    procs.add &"  {exportTypeNim(entryType)}(reference: "
+    procs.add &"{procPrefix}_get(s{refSuffix}, i))\n"
+  else:
+    procs.add &"  {procPrefix}_get(s{refSuffix}, i)"
+    procs.add convertImportToNim(entryType)
+    procs.add "\n"
   procs.add "\n"
 
   procs.add &"proc {procPrefix}_set(s: pointer, "
-  procs.add &"i: int, v: {entryName})"
+  procs.add &"i: int, v: {exportTypeCImport(entryType)})"
   procs.add " {.importc: \""
   procs.add &"{procPrefix}_set"
   procs.add "\", cdecl.}\n"
   procs.add "\n"
 
-  procs.add &"proc `[]=`*(s: {niceName}, i: int, v: {entryName}) =\n"
-  procs.add &"  {procPrefix}_set(s{refSuffix}, i, v)\n"
+  procs.add &"proc `[]=`*(s: {niceName}, i: int, v: {exportArgTypeNim(entryType)}) =\n"
+  procs.add &"  {procPrefix}_set(s{refSuffix}, i, v{convertToPointer(entryType)})\n"
   procs.add "\n"
 
   procs.add &"proc {procPrefix}_delete(s: pointer, i: int)"
@@ -354,8 +432,12 @@ proc exportRefObjectNim*(
       procs.add &"{toVarCase(objName)}: {objName}): "
       procs.add &"{exportTypeNim(fieldType)}"
       procs.add " {.inline.} =\n"
-      procs.add &"  {getProcName}({toVarCase(objName)}.reference)"
-      procs.add convertImportToNim(fieldType)
+      if fieldType.isRefObjectLike:
+        procs.add &"  {exportTypeNim(fieldType)}(reference: "
+        procs.add &"{getProcName}({toVarCase(objName)}.reference))"
+      else:
+        procs.add &"  {getProcName}({toVarCase(objName)}.reference)"
+        procs.add convertImportToNim(fieldType)
       procs.add "\n"
       procs.add "\n"
 
@@ -374,7 +456,7 @@ proc exportRefObjectNim*(
       # Nim wrapper passes .reference
       procs.add &"proc `{fieldName}=`*("
       procs.add &"{toVarCase(objName)}: {objName}, "
-      procs.add &"{fieldName}: {fieldType.repr}) =\n"
+      procs.add &"{fieldName}: {exportArgTypeNim(fieldType)}) =\n"
       procs.add &"  {setProcName}({toVarCase(objName)}.reference, "
       procs.add &"{fieldName}{convertToPointer(fieldType)})"
       procs.add "\n"
@@ -399,7 +481,7 @@ proc exportRefObjectNim*(
         helperName,
         &"$lib_{objNameSnaked}_{fieldNameSnaked}",
         &".{toVarCase(objName)}",
-        fieldType[1].repr
+        fieldType[1]
       )
 
 proc exportSeqNim*(sym: NimNode) =
@@ -413,7 +495,7 @@ proc exportSeqNim*(sym: NimNode) =
     seqName,
     &"$lib_{seqNameSnaked}",
     "",
-    sym[1].repr
+    sym[1]
   )
 
   let newSeqProcName = &"$lib_new_{seqNameSnaked}"

--- a/src/genny/languages/nim.nim
+++ b/src/genny/languages/nim.nim
@@ -246,11 +246,11 @@ proc exportProcNim*(
   procs.removeSuffix ", "
   procs.add ")"
   if procReturn.kind != nnkEmpty:
-    procs.add &": {exportTypeNim(procReturn)}"
+    procs.add &": {exportArgTypeNim(procReturn)}"
   procs.add " {.inline.} =\n"
   if returnsRefObject:
     # Wrap returned pointer in ref object
-    procs.add &"  result = {exportTypeNim(procReturn)}(reference: "
+    procs.add &"  result = {exportArgTypeNim(procReturn)}(reference: "
   elif procReturn.kind != nnkEmpty:
     procs.add "  result = "
   else:
@@ -263,6 +263,8 @@ proc exportProcNim*(
   procs.add ")"
   if returnsRefObject:
     procs.add ")"  # Close the TypeName(reference: ...)
+  elif procReturn.kind != nnkEmpty:
+    procs.add convertImportToNim(procReturn)
   procs.add "\n"
   if procRaises:
     procs.add "  if checkError():\n"
@@ -430,7 +432,7 @@ proc exportRefObjectNim*(
       # Nim wrapper passes .reference
       procs.add &"proc {fieldName}*("
       procs.add &"{toVarCase(objName)}: {objName}): "
-      procs.add &"{exportTypeNim(fieldType)}"
+      procs.add &"{exportArgTypeNim(fieldType)}"
       procs.add " {.inline.} =\n"
       if fieldType.isRefObjectLike:
         procs.add &"  {exportTypeNim(fieldType)}(reference: "

--- a/src/genny/languages/node.nim
+++ b/src/genny/languages/node.nim
@@ -83,7 +83,10 @@ proc exportTypeNode(sym: NimNode): string =
           "'uint64'"  # Treat ref objects as opaque pointers
 
 proc jsArgValue(argType: NimNode, argName: string): string =
-  if argType.isSeqLike or argType.isRefObjectLike:
+  let typ = argType.stripSink
+  if typ.repr == "Rune":
+    &"runeToInt({argName})"
+  elif typ.isSeqLike or typ.isRefObjectLike:
     &"{argName}.ref"
   else:
     argName
@@ -92,6 +95,8 @@ proc jsReturnValue(returnType: NimNode, call: string): string =
   let typ = returnType.stripSink
   if typ.kind == nnkEmpty:
     call
+  elif typ.repr == "Rune":
+    &"intToRune({call})"
   elif typ.isSeqLike:
     &"new {typ.getName()}({call})"
   elif typ.isRefObjectLike:
@@ -418,6 +423,7 @@ proc exportSeqNode*(sym: NimNode) =
 const header = """
 const koffi = require('koffi');
 const path = require('path');
+const assert = require('assert');
 
 // Determine library path based on platform.
 let libName;
@@ -436,6 +442,19 @@ class $LibException extends Error {
     super(message);
     this.name = '$LibException';
   }
+}
+
+function runeToInt(value) {
+  assert.strictEqual(typeof value, 'string', 'expected rune string');
+  const chars = Array.from(value);
+  assert.strictEqual(chars.length, 1, 'expected exactly one Unicode scalar value');
+  const code = chars[0].codePointAt(0);
+  assert(!(code >= 0xd800 && code <= 0xdfff), 'expected Unicode scalar value');
+  return code;
+}
+
+function intToRune(value) {
+  return String.fromCodePoint(value);
 }
 
 """

--- a/src/genny/languages/node.nim
+++ b/src/genny/languages/node.nim
@@ -6,22 +6,53 @@ var
   types {.compiletime.}: string
   procs {.compiletime.}: string
   exports {.compiletime.}: string
+  objects {.compiletime.}: HashSet[string]
   refObjects {.compiletime.}: HashSet[string]
 
+proc stripSink(sym: NimNode): NimNode =
+  if sym.kind == nnkBracketExpr and sym[0].repr == "sink":
+    sym[1]
+  else:
+    sym
+
+proc isSeqLike(sym: NimNode): bool =
+  let typ = sym.stripSink
+  typ.kind == nnkBracketExpr and typ[0].repr in ["seq", "openArray"]
+
+proc typeBody(sym: NimNode): NimNode =
+  let typ = sym.stripSink
+  if typ.kind == nnkSym:
+    let impl = typ.getImpl()
+    if impl.kind == nnkTypeDef:
+      return impl[2]
+  typ
+
+proc isObjectLike(sym: NimNode): bool =
+  let typ = sym.stripSink
+  typ.repr in objects or typ.typeBody.kind == nnkObjectTy
+
+proc isRefObjectLike(sym: NimNode): bool =
+  let typ = sym.stripSink
+  typ.repr in refObjects or typ.typeBody.kind == nnkRefTy
+
+proc isEnumLike(sym: NimNode): bool =
+  sym.typeBody.kind == nnkEnumTy
+
 proc exportTypeNode(sym: NimNode): string =
-  if sym.kind == nnkBracketExpr:
-    if sym[0].repr == "array":
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if typ[0].repr == "array":
       let
-        entryCount = sym[1].repr
-        entryType = exportTypeNode(sym[2])
+        entryCount = typ[1].repr
+        entryType = exportTypeNode(typ[2])
       result = &"koffi.array({entryType}, {entryCount})"
-    elif sym[0].repr == "seq":
+    elif typ.isSeqLike:
       result = "'uint64'"  # Opaque pointer
     else:
-      error(&"Unexpected bracket expression {sym[0].repr}[")
+      error(&"Unexpected bracket expression {typ[0].repr}[")
   else:
     result =
-      case sym.repr:
+      case typ.repr:
       of "string": "'str'"
       of "bool": "'bool'"
       of "byte": "'uint8'"
@@ -44,7 +75,29 @@ proc exportTypeNode(sym: NimNode): string =
       of "Mat3": "Matrix3"
       of "": "'void'"
       else:
-        "'uint64'"  # Treat ref objects as opaque pointers
+        if typ.isEnumLike:
+          "'int8'"
+        elif typ.isObjectLike:
+          typ.repr
+        else:
+          "'uint64'"  # Treat ref objects as opaque pointers
+
+proc jsArgValue(argType: NimNode, argName: string): string =
+  if argType.isSeqLike or argType.isRefObjectLike:
+    &"{argName}.ref"
+  else:
+    argName
+
+proc jsReturnValue(returnType: NimNode, call: string): string =
+  let typ = returnType.stripSink
+  if typ.kind == nnkEmpty:
+    call
+  elif typ.isSeqLike:
+    &"new {typ.getName()}({call})"
+  elif typ.isRefObjectLike:
+    &"new {typ.getName()}({call})"
+  else:
+    call
 
 proc convertExportFromNode*(sym: NimNode): string =
   discard
@@ -155,19 +208,23 @@ proc exportProcNode*(
   types.add "  "
   if procReturn.kind != nnkEmpty:
     types.add "return "
-  types.add &"{apiProcName}("
+  var call = &"{apiProcName}("
   for i, param in procParams[0 .. ^1]:
     if isRefObject and i == 0:
-      types.add "this.ref"
+      call.add "this.ref"
     else:
-      types.add &"{toSnakeCase(param[0].repr)}"
-    types.add &", "
-  types.removeSuffix ", "
-  types.add ");\n"
+      let argName = toSnakeCase(param[0].repr)
+      call.add jsArgValue(param[^2], argName)
+    call.add &", "
+  call.removeSuffix ", "
+  call.add ")"
+  types.add jsReturnValue(procReturn, call)
+  types.add ";\n"
   types.add "}\n\n"
 
 proc exportObjectNode*(sym: NimNode, constructor: NimNode) =
   let objName = sym.repr
+  objects.incl(objName)
 
   # Define struct type with koffi
   types.add &"const {objName} = koffi.struct('{objName}', {{\n"
@@ -223,14 +280,16 @@ proc genSeqProcs(objName, className, procPrefix, selfAccessor: string, entryType
 
   # get
   procs.add &"const {procPrefix}_get = lib.func('{procPrefix}_get', {exportTypeNode(entryType)}, ['uint64', 'int64']);\n"
+  let getCall = &"{procPrefix}_get({selfAccessor}, index)"
   types.add &"{className}.prototype.get = function(index) {{\n"
-  types.add &"  return {procPrefix}_get({selfAccessor}, index);\n"
+  types.add &"  return {jsReturnValue(entryType, getCall)};\n"
   types.add "};\n"
 
   # set
   procs.add &"const {procPrefix}_set = lib.func('{procPrefix}_set', 'void', ['uint64', 'int64', {exportTypeNode(entryType)}]);\n"
+  let setValue = jsArgValue(entryType, "value")
   types.add &"{className}.prototype.set = function(index, value) {{\n"
-  types.add &"  {procPrefix}_set({selfAccessor}, index, value);\n"
+  types.add &"  {procPrefix}_set({selfAccessor}, index, {setValue});\n"
   types.add "};\n"
 
   # delete
@@ -242,7 +301,7 @@ proc genSeqProcs(objName, className, procPrefix, selfAccessor: string, entryType
   # add
   procs.add &"const {procPrefix}_add = lib.func('{procPrefix}_add', 'void', ['uint64', {exportTypeNode(entryType)}]);\n"
   types.add &"{className}.prototype.add = function(value) {{\n"
-  types.add &"  {procPrefix}_add({selfAccessor}, value);\n"
+  types.add &"  {procPrefix}_add({selfAccessor}, {setValue});\n"
   types.add "};\n"
 
   # clear
@@ -280,7 +339,8 @@ proc exportRefObjectNode*(
     types.add ") {\n"
     types.add &"  const ref = {constructorLibProc}("
     for i, param in constructorParams[0 .. ^1]:
-      types.add &"{toSnakeCase(param[0].repr)}"
+      let argName = toSnakeCase(param[0].repr)
+      types.add jsArgValue(param[^2], argName)
       types.add ", "
     types.removeSuffix ", "
     types.add ");\n"
@@ -299,8 +359,10 @@ proc exportRefObjectNode*(
       procs.add &"const {setProcName} = lib.func('{setProcName}', 'void', ['uint64', {exportTypeNode(fieldType)}]);\n"
 
       types.add &"Object.defineProperty({objName}.prototype, '{fieldName}', {{\n"
-      types.add &"  get: function() {{ return {getProcName}(this.ref); }},\n"
-      types.add &"  set: function(v) {{ {setProcName}(this.ref, v); }}\n"
+      let getCall = &"{getProcName}(this.ref)"
+      let setValue = jsArgValue(fieldType, "v")
+      types.add &"  get: function() {{ return {jsReturnValue(fieldType, getCall)}; }},\n"
+      types.add &"  set: function(v) {{ {setProcName}(this.ref, {setValue}); }}\n"
       types.add "});\n"
 
     else:
@@ -382,6 +444,6 @@ proc writeNode*(dir, lib: string) =
   createDir(dir)
   writeFile(
     &"{dir}/{toSnakeCase(lib)}.js",
-    (header & procs & "\n" & types & "\n" & exports)
+    (header & types & "\n" & procs & "\n" & exports)
       .replace("$Lib", lib).replace("$lib", toSnakeCase(lib))
   )

--- a/src/genny/languages/python.nim
+++ b/src/genny/languages/python.nim
@@ -74,6 +74,26 @@ proc convertImportToPy*(sym: NimNode): string =
   if typ.repr == "string":
     result = ".decode(\"utf8\")"
 
+proc exportExprPy(expr: string, sym: NimNode): string =
+  let typ = sym.stripSink
+  case typ.repr
+  of "string":
+    expr & ".encode(\"utf8\")"
+  of "Rune":
+    &"_rune_to_int({expr})"
+  else:
+    expr
+
+proc importExprPy(expr: string, sym: NimNode): string =
+  let typ = sym.stripSink
+  case typ.repr
+  of "string":
+    expr & ".decode(\"utf8\")"
+  of "Rune":
+    &"_int_to_rune({expr})"
+  else:
+    expr
+
 proc toArgTypes(args: openarray[NimNode]): seq[string] =
   for arg in args:
     result.add exportTypePy(arg)
@@ -197,15 +217,17 @@ proc exportProcPy*(
   types.add "    "
   if procReturn.kind != nnkEmpty:
     types.add "result = "
-  types.add &"dll.$lib_{apiProcName}("
+  var call = &"dll.$lib_{apiProcName}("
   for i, param in procParams[0 .. ^1]:
     if onClass and i == 0:
-      types.add "self"
+      call.add "self"
     else:
-      types.add &"{toSnakeCase(param[0].repr)}{convertExportFromPy(param[1])}"
-    types.add &", "
-  types.removeSuffix ", "
-  types.add &"){convertImportToPy(procReturn)}\n"
+      call.add exportExprPy(toSnakeCase(param[0].repr), param[1])
+    call.add &", "
+  call.removeSuffix ", "
+  call.add ")"
+  types.add importExprPy(call, procReturn)
+  types.add "\n"
   if procRaises:
     if onClass:
       types.add "    "
@@ -253,7 +275,7 @@ proc exportObjectPy*(sym: NimNode, constructor: NimNode) =
     types.add "):\n"
     types.add &"        tmp = dll.$lib_{toSnakeCase(objName)}("
     for param in constructorParams:
-      types.add &"{toSnakeCase(param[0].repr)}"
+      types.add exportExprPy(toSnakeCase(param[0].repr), param[1])
       types.add ", "
     types.removeSuffix ", "
     types.add ")\n"
@@ -324,11 +346,13 @@ proc genSeqProcs(objName, procPrefix, selfSuffix: string, entryType: NimNode) =
   types.add "\n"
 
   types.add &"{baseIndent}def __getitem__(self, index):\n"
-  types.add &"{baseIndent}    return dll.{procPrefix}_get(self{selfSuffix}, index){convertImportToPy(entryType)}\n"
+  let getCall = &"dll.{procPrefix}_get(self{selfSuffix}, index)"
+  types.add &"{baseIndent}    return {importExprPy(getCall, entryType)}\n"
   types.add "\n"
 
   types.add &"{baseIndent}def __setitem__(self, index, value):\n"
-  types.add &"{baseIndent}    dll.{procPrefix}_set(self{selfSuffix}, index, value{convertExportFromPy(entryType)})\n"
+  let setValue = exportExprPy("value", entryType)
+  types.add &"{baseIndent}    dll.{procPrefix}_set(self{selfSuffix}, index, {setValue})\n"
   types.add "\n"
 
   types.add &"{baseIndent}def __delitem__(self, index):\n"
@@ -336,7 +360,7 @@ proc genSeqProcs(objName, procPrefix, selfSuffix: string, entryType: NimNode) =
   types.add "\n"
 
   types.add &"{baseIndent}def append(self, value):\n"
-  types.add &"{baseIndent}    dll.{procPrefix}_add(self{selfSuffix}, value)\n"
+  types.add &"{baseIndent}    dll.{procPrefix}_add(self{selfSuffix}, {setValue})\n"
   types.add "\n"
 
   types.add &"{baseIndent}def clear(self):\n"
@@ -382,7 +406,7 @@ proc exportRefObjectPy*(
     types.add &"        result = "
     types.add &"{constructorLibProc}("
     for param in constructorParams:
-      types.add &"{toSnakeCase(param[0].repr)}{convertExportFromPy(param[1])}"
+      types.add exportExprPy(toSnakeCase(param[0].repr), param[1])
       types.add ", "
     types.removeSuffix ", "
     types.add ")\n"
@@ -408,7 +432,8 @@ proc exportRefObjectPy*(
       types.add "    @property\n"
       types.add &"    def {fieldNameSnaked}(self):\n"
       types.add "        "
-      types.add &"return {getProcName}(self){convertImportToPy(fieldType)}\n"
+      let getCall = &"{getProcName}(self)"
+      types.add &"return {importExprPy(getCall, fieldType)}\n"
 
       let setProcName = &"dll.$lib_{objNameSnaked}_set_{fieldNameSnaked}"
 
@@ -417,7 +442,7 @@ proc exportRefObjectPy*(
       types.add &"    def {fieldNameSnaked}(self, {fieldNameSnaked}):\n"
       types.add "        "
       types.add &"{setProcName}(self, "
-      types.add &"{fieldNameSnaked}{convertExportFromPy(fieldType)}"
+      types.add exportExprPy(fieldNameSnaked, fieldType)
       types.add ")\n"
       types.add "\n"
 
@@ -483,6 +508,16 @@ dll = cdll.LoadLibrary(os.path.join(dir, libName))
 
 class $LibError(Exception):
     pass
+
+def _rune_to_int(value):
+    assert isinstance(value, str), "expected rune string"
+    assert len(value) == 1, "expected exactly one Unicode scalar value"
+    code = ord(value)
+    assert code < 0xD800 or code > 0xDFFF, "expected Unicode scalar value"
+    return code
+
+def _int_to_rune(value):
+    return chr(value)
 
 class SeqIterator(object):
     def __init__(self, seq):

--- a/src/genny/languages/python_native.nim
+++ b/src/genny/languages/python_native.nim
@@ -223,7 +223,9 @@ proc pyFromC(expr: string, typ: NimNode): string =
     &"PyBool_FromLong((long)({expr}))"
   of "byte", "uint8", "uint16", "uint32", "uint64", "uint":
     &"PyLong_FromUnsignedLongLong((unsigned long long)({expr}))"
-  of "int8", "int16", "int32", "int64", "int", "Rune":
+  of "Rune":
+    &"PyUnicode_FromOrdinal((int)({expr}))"
+  of "int8", "int16", "int32", "int64", "int":
     &"PyLong_FromLongLong((long long)({expr}))"
   of "float32", "float64", "float":
     &"PyFloat_FromDouble((double)({expr}))"
@@ -251,7 +253,11 @@ proc convertPyToC(pyExpr, outExpr: string, typ: NimNode, label: string): string 
     &"  {{ unsigned long genny_value = PyLong_AsUnsignedLong({pyExpr}); if (PyErr_Occurred()) return NULL; if (genny_value > 255UL) {{ PyErr_Format(PyExc_OverflowError, \"%s out of range\", {cString(label)}); return NULL; }} {outExpr} = (unsigned char)genny_value; }}\n"
   of "uint16", "uint32", "uint64", "uint":
     &"  {{ unsigned long long genny_value = PyLong_AsUnsignedLongLong({pyExpr}); if (PyErr_Occurred()) return NULL; {outExpr} = ({cType(baseTyp)})genny_value; }}\n"
-  of "int8", "int16", "int32", "int64", "int", "Rune":
+  of "Rune":
+    &"  if (!PyUnicode_Check({pyExpr})) {{ PyErr_Format(PyExc_AssertionError, \"%s must be a single-character string\", {cString(label)}); return NULL; }}\n" &
+    &"  {{ Py_ssize_t genny_len = PyUnicode_GetLength({pyExpr}); if (genny_len < 0) return NULL; if (genny_len != 1) {{ PyErr_Format(PyExc_AssertionError, \"%s must be exactly one Unicode scalar value\", {cString(label)}); return NULL; }} }}\n" &
+    &"  {{ Py_UCS4 genny_rune = PyUnicode_ReadChar({pyExpr}, 0); if (genny_rune == (Py_UCS4)-1 && PyErr_Occurred()) return NULL; if (genny_rune >= 0xD800 && genny_rune <= 0xDFFF) {{ PyErr_Format(PyExc_AssertionError, \"%s must be a Unicode scalar value\", {cString(label)}); return NULL; }} {outExpr} = ({cType(baseTyp)})genny_rune; }}\n"
+  of "int8", "int16", "int32", "int64", "int":
     &"  {{ long long genny_value = PyLong_AsLongLong({pyExpr}); if (PyErr_Occurred()) return NULL; {outExpr} = ({cType(baseTyp)})genny_value; }}\n"
   of "float32", "float64", "float":
     &"  {{ double genny_value = PyFloat_AsDouble({pyExpr}); if (PyErr_Occurred()) return NULL; {outExpr} = ({cType(baseTyp)})genny_value; }}\n"

--- a/src/genny/languages/zig.nim
+++ b/src/genny/languages/zig.nim
@@ -5,23 +5,34 @@ import
 var
   code {.compiletime.}: string
 
-proc exportTypeZig(sym: NimNode): string =
-  if sym.kind == nnkBracketExpr:
-    if sym[0].repr == "array":
-      let
-        entryCount = sym[1].repr
-        entryType = exportTypeZig(sym[2])
-      result = &"[{entryCount}]{entryType}"
-    elif sym[0].repr == "seq":
-      result = &"*{sym.getSeqName()}"
-    else:
-      error(&"Unexpected bracket expression {sym[0].repr}[")
+proc stripSink(sym: NimNode): NimNode =
+  if sym.kind == nnkBracketExpr and sym[0].repr == "sink":
+    sym[1]
   else:
-      if sym.typeKind == ntyRef and sym.repr != "nil":
-        result = &"*{sym.repr}"
+    sym
+
+proc isSeqLike(sym: NimNode): bool =
+  let typ = sym.stripSink
+  typ.kind == nnkBracketExpr and typ[0].repr in ["seq", "openArray"]
+
+proc exportTypeZig(sym: NimNode): string =
+  let typ = sym.stripSink
+  if typ.kind == nnkBracketExpr:
+    if typ[0].repr == "array":
+      let
+        entryCount = typ[1].repr
+        entryType = exportTypeZig(typ[2])
+      result = &"[{entryCount}]{entryType}"
+    elif typ.isSeqLike:
+      result = &"*{typ.getSeqName()}"
+    else:
+      error(&"Unexpected bracket expression {typ[0].repr}[")
+  else:
+      if typ.typeKind == ntyRef and typ.repr != "nil":
+        result = &"*{typ.repr}"
       else:
         result =
-          case sym.repr:
+          case typ.repr:
           of "string": "[:0]const u8"
           of "bool": "bool"
           of "int8": "i8"
@@ -43,7 +54,7 @@ proc exportTypeZig(sym: NimNode): string =
           of "Mat3": "Matrix3"
           of "", "nil": "void"
           else:
-            sym.repr
+            typ.repr
 
 proc convertExportFromZig*(inner: string, sym: string): string =
   if sym == "[:0]const u8":

--- a/src/genny/languages/zig.nim
+++ b/src/genny/languages/zig.nim
@@ -59,14 +59,26 @@ proc exportTypeZig(sym: NimNode): string =
 proc convertExportFromZig*(inner: string, sym: string): string =
   if sym == "[:0]const u8":
     inner & ".ptr"
+  elif sym == "u21":
+    &"@intCast({inner})"
   else:
     inner
 
 proc convertImportToZig*(inner: string, sym: string): string =
   if sym == "[:0]const u8":
     "std.mem.span(" & inner & ")"
+  elif sym == "u21":
+    &"@intCast({inner})"
   else:
     inner
+
+proc exportTypeZigAbi(sym: string): string =
+  if sym == "[:0]const u8":
+    "[*:0]const u8"
+  elif sym == "u21":
+    "i32"
+  else:
+    sym.replace("[:0]", "[*:0]")
 
 proc toArgSeq(args: seq[NimNode]): seq[(string, string)] =
   for i, arg in args[0 .. ^1]:
@@ -111,12 +123,12 @@ proc exportProc(
     else:
       code.add toSnakeCase(param[0])
     code.add ": "
-    code.add param[1].replace("[:0]", "[*:0]")
+    code.add exportTypeZigAbi(param[1])
     code.add &", "
   code.removeSuffix ", "
   code.add ") callconv(.C) "
   if procReturn != "":
-    code.add procReturn.replace("[:0]", "[*:0]");
+    code.add exportTypeZigAbi(procReturn);
   else:
     code.add "void"
   code.add ";\n"

--- a/tests/generated/internal.nim
+++ b/tests/generated/internal.nim
@@ -19,7 +19,8 @@ proc test_simple_ref_obj_unref*(x: SimpleRefObj) {.raises: [], cdecl, exportc, d
 
 proc test_new_simple_ref_obj*(): SimpleRefObj {.raises: [], cdecl, exportc, dynlib.} =
   result = newSimpleRefObj()
-  GC_ref(result)
+  if result != nil:
+    GC_ref(result)
 
 proc test_simple_ref_obj_get_simple_ref_a*(simple_ref_obj: SimpleRefObj): int {.raises: [], cdecl, exportc, dynlib.} =
   simple_ref_obj.simpleRefA
@@ -69,7 +70,8 @@ proc test_ref_obj_with_seq_unref*(x: RefObjWithSeq) {.raises: [], cdecl, exportc
 
 proc test_new_ref_obj_with_seq*(): RefObjWithSeq {.raises: [], cdecl, exportc, dynlib.} =
   result = newRefObjWithSeq()
-  GC_ref(result)
+  if result != nil:
+    GC_ref(result)
 
 proc test_ref_obj_with_seq_data_len*(ref_obj_with_seq: RefObjWithSeq): int {.raises: [], cdecl, exportc, dynlib.} =
   ref_obj_with_seq.data.len
@@ -129,5 +131,7 @@ proc test_seq_string_unref*(s: SeqString) {.raises: [], cdecl, exportc, dynlib.}
   GC_unref(s)
 
 proc test_get_datas*(): SeqString {.raises: [], cdecl, exportc, dynlib.} =
-  SeqString(s: getDatas())
+  result = SeqString(s: getDatas())
+  if result != nil:
+    GC_ref(result)
 

--- a/tests/generated/test.js
+++ b/tests/generated/test.js
@@ -1,5 +1,6 @@
 const koffi = require('koffi');
 const path = require('path');
+const assert = require('assert');
 
 // Determine library path based on platform.
 let libName;
@@ -20,40 +21,18 @@ class testException extends Error {
   }
 }
 
-const test_simple_call = lib.func('test_simple_call', 'int64', ['int64']);
-const test_simple_ref_obj_unref = lib.func('test_simple_ref_obj_unref', 'void', ['uint64']);
-const test_new_simple_ref_obj = lib.func('test_new_simple_ref_obj', 'uint64', []);
-const test_simple_ref_obj_get_simple_ref_a = lib.func('test_simple_ref_obj_get_simple_ref_a', 'int64', ['uint64']);
-const test_simple_ref_obj_set_simple_ref_a = lib.func('test_simple_ref_obj_set_simple_ref_a', 'void', ['uint64', 'int64']);
-const test_simple_ref_obj_get_simple_ref_b = lib.func('test_simple_ref_obj_get_simple_ref_b', 'uint8', ['uint64']);
-const test_simple_ref_obj_set_simple_ref_b = lib.func('test_simple_ref_obj_set_simple_ref_b', 'void', ['uint64', 'uint8']);
-const test_simple_ref_obj_doit = lib.func('test_simple_ref_obj_doit', 'void', ['uint64']);
-const test_seq_int_unref = lib.func('test_seq_int_unref', 'void', ['uint64']);
-const test_new_seq_int = lib.func('test_new_seq_int', 'uint64', []);
-const test_seq_int_len = lib.func('test_seq_int_len', 'int64', ['uint64']);
-const test_seq_int_get = lib.func('test_seq_int_get', 'int64', ['uint64', 'int64']);
-const test_seq_int_set = lib.func('test_seq_int_set', 'void', ['uint64', 'int64', 'int64']);
-const test_seq_int_delete = lib.func('test_seq_int_delete', 'void', ['uint64', 'int64']);
-const test_seq_int_add = lib.func('test_seq_int_add', 'void', ['uint64', 'int64']);
-const test_seq_int_clear = lib.func('test_seq_int_clear', 'void', ['uint64']);
-const test_ref_obj_with_seq_unref = lib.func('test_ref_obj_with_seq_unref', 'void', ['uint64']);
-const test_new_ref_obj_with_seq = lib.func('test_new_ref_obj_with_seq', 'uint64', []);
-const test_ref_obj_with_seq_data_len = lib.func('test_ref_obj_with_seq_data_len', 'int64', ['uint64']);
-const test_ref_obj_with_seq_data_get = lib.func('test_ref_obj_with_seq_data_get', 'uint8', ['uint64', 'int64']);
-const test_ref_obj_with_seq_data_set = lib.func('test_ref_obj_with_seq_data_set', 'void', ['uint64', 'int64', 'uint8']);
-const test_ref_obj_with_seq_data_delete = lib.func('test_ref_obj_with_seq_data_delete', 'void', ['uint64', 'int64']);
-const test_ref_obj_with_seq_data_add = lib.func('test_ref_obj_with_seq_data_add', 'void', ['uint64', 'uint8']);
-const test_ref_obj_with_seq_data_clear = lib.func('test_ref_obj_with_seq_data_clear', 'void', ['uint64']);
-const test_simple_obj_with_proc_extra_proc = lib.func('test_simple_obj_with_proc_extra_proc', 'void', ['uint64']);
-const test_seq_string_unref = lib.func('test_seq_string_unref', 'void', ['uint64']);
-const test_new_seq_string = lib.func('test_new_seq_string', 'uint64', []);
-const test_seq_string_len = lib.func('test_seq_string_len', 'int64', ['uint64']);
-const test_seq_string_get = lib.func('test_seq_string_get', 'str', ['uint64', 'int64']);
-const test_seq_string_set = lib.func('test_seq_string_set', 'void', ['uint64', 'int64', 'str']);
-const test_seq_string_delete = lib.func('test_seq_string_delete', 'void', ['uint64', 'int64']);
-const test_seq_string_add = lib.func('test_seq_string_add', 'void', ['uint64', 'str']);
-const test_seq_string_clear = lib.func('test_seq_string_clear', 'void', ['uint64']);
-const test_get_datas = lib.func('test_get_datas', 'uint64', []);
+function runeToInt(value) {
+  assert.strictEqual(typeof value, 'string', 'expected rune string');
+  const chars = Array.from(value);
+  assert.strictEqual(chars.length, 1, 'expected exactly one Unicode scalar value');
+  const code = chars[0].codePointAt(0);
+  assert(!(code >= 0xd800 && code <= 0xdfff), 'expected Unicode scalar value');
+  return code;
+}
+
+function intToRune(value) {
+  return String.fromCodePoint(value);
+}
 
 /**
  * Returns the integer passed in.
@@ -236,9 +215,44 @@ SeqString.prototype.clear = function() {
   test_seq_string_clear(this.ref);
 };
 function getDatas() {
-  return test_get_datas();
+  return new SeqString(test_get_datas());
 }
 
+
+const test_simple_call = lib.func('test_simple_call', 'int64', ['int64']);
+const test_simple_ref_obj_unref = lib.func('test_simple_ref_obj_unref', 'void', ['uint64']);
+const test_new_simple_ref_obj = lib.func('test_new_simple_ref_obj', 'uint64', []);
+const test_simple_ref_obj_get_simple_ref_a = lib.func('test_simple_ref_obj_get_simple_ref_a', 'int64', ['uint64']);
+const test_simple_ref_obj_set_simple_ref_a = lib.func('test_simple_ref_obj_set_simple_ref_a', 'void', ['uint64', 'int64']);
+const test_simple_ref_obj_get_simple_ref_b = lib.func('test_simple_ref_obj_get_simple_ref_b', 'uint8', ['uint64']);
+const test_simple_ref_obj_set_simple_ref_b = lib.func('test_simple_ref_obj_set_simple_ref_b', 'void', ['uint64', 'uint8']);
+const test_simple_ref_obj_doit = lib.func('test_simple_ref_obj_doit', 'void', ['uint64']);
+const test_seq_int_unref = lib.func('test_seq_int_unref', 'void', ['uint64']);
+const test_new_seq_int = lib.func('test_new_seq_int', 'uint64', []);
+const test_seq_int_len = lib.func('test_seq_int_len', 'int64', ['uint64']);
+const test_seq_int_get = lib.func('test_seq_int_get', 'int64', ['uint64', 'int64']);
+const test_seq_int_set = lib.func('test_seq_int_set', 'void', ['uint64', 'int64', 'int64']);
+const test_seq_int_delete = lib.func('test_seq_int_delete', 'void', ['uint64', 'int64']);
+const test_seq_int_add = lib.func('test_seq_int_add', 'void', ['uint64', 'int64']);
+const test_seq_int_clear = lib.func('test_seq_int_clear', 'void', ['uint64']);
+const test_ref_obj_with_seq_unref = lib.func('test_ref_obj_with_seq_unref', 'void', ['uint64']);
+const test_new_ref_obj_with_seq = lib.func('test_new_ref_obj_with_seq', 'uint64', []);
+const test_ref_obj_with_seq_data_len = lib.func('test_ref_obj_with_seq_data_len', 'int64', ['uint64']);
+const test_ref_obj_with_seq_data_get = lib.func('test_ref_obj_with_seq_data_get', 'uint8', ['uint64', 'int64']);
+const test_ref_obj_with_seq_data_set = lib.func('test_ref_obj_with_seq_data_set', 'void', ['uint64', 'int64', 'uint8']);
+const test_ref_obj_with_seq_data_delete = lib.func('test_ref_obj_with_seq_data_delete', 'void', ['uint64', 'int64']);
+const test_ref_obj_with_seq_data_add = lib.func('test_ref_obj_with_seq_data_add', 'void', ['uint64', 'uint8']);
+const test_ref_obj_with_seq_data_clear = lib.func('test_ref_obj_with_seq_data_clear', 'void', ['uint64']);
+const test_simple_obj_with_proc_extra_proc = lib.func('test_simple_obj_with_proc_extra_proc', 'void', [SimpleObjWithProc]);
+const test_seq_string_unref = lib.func('test_seq_string_unref', 'void', ['uint64']);
+const test_new_seq_string = lib.func('test_new_seq_string', 'uint64', []);
+const test_seq_string_len = lib.func('test_seq_string_len', 'int64', ['uint64']);
+const test_seq_string_get = lib.func('test_seq_string_get', 'str', ['uint64', 'int64']);
+const test_seq_string_set = lib.func('test_seq_string_set', 'void', ['uint64', 'int64', 'str']);
+const test_seq_string_delete = lib.func('test_seq_string_delete', 'void', ['uint64', 'int64']);
+const test_seq_string_add = lib.func('test_seq_string_add', 'void', ['uint64', 'str']);
+const test_seq_string_clear = lib.func('test_seq_string_clear', 'void', ['uint64']);
+const test_get_datas = lib.func('test_get_datas', 'uint64', []);
 
 exports.SIMPLE_CONST = 123;
 exports.SimpleEnum = 'int8';

--- a/tests/generated/test.nim
+++ b/tests/generated/test.nim
@@ -205,20 +205,20 @@ proc test_seq_string_len(s: pointer): int {.importc: "test_seq_string_len", cdec
 proc len*(s: SeqString): int =
   test_seq_string_len(s.reference)
 
-proc test_seq_string_add(s: pointer, v: string) {.importc: "test_seq_string_add", cdecl.}
+proc test_seq_string_add(s: pointer, v: cstring) {.importc: "test_seq_string_add", cdecl.}
 
 proc add*(s: SeqString, v: string) =
-  test_seq_string_add(s.reference, v)
+  test_seq_string_add(s.reference, v.cstring)
 
-proc test_seq_string_get(s: pointer, i: int): string {.importc: "test_seq_string_get", cdecl.}
+proc test_seq_string_get(s: pointer, i: int): cstring {.importc: "test_seq_string_get", cdecl.}
 
 proc `[]`*(s: SeqString, i: int): string =
-  test_seq_string_get(s.reference, i)
+  test_seq_string_get(s.reference, i).`$`
 
-proc test_seq_string_set(s: pointer, i: int, v: string) {.importc: "test_seq_string_set", cdecl.}
+proc test_seq_string_set(s: pointer, i: int, v: cstring) {.importc: "test_seq_string_set", cdecl.}
 
 proc `[]=`*(s: SeqString, i: int, v: string) =
-  test_seq_string_set(s.reference, i, v)
+  test_seq_string_set(s.reference, i, v.cstring)
 
 proc test_seq_string_delete(s: pointer, i: int) {.importc: "test_seq_string_delete", cdecl.}
 

--- a/tests/generated/test.nim
+++ b/tests/generated/test.nim
@@ -20,7 +20,7 @@ type SimpleEnum* = enum
   Second
   Third
 
-type SimpleObj* = object
+type SimpleObj* {.bycopy.} = object
   simpleA*: int
   simpleB*: byte
   simpleC*: bool
@@ -63,7 +63,7 @@ proc `=destroy`(x: RefObjWithSeqObj) =
   if x.reference != nil:
     test_ref_obj_with_seq_unref(x.reference)
 
-type SimpleObjWithProc* = object
+type SimpleObjWithProc* {.bycopy.} = object
   simpleA*: int
   simpleB*: byte
   simpleC*: bool

--- a/tests/generated/test.py
+++ b/tests/generated/test.py
@@ -13,6 +13,16 @@ dll = cdll.LoadLibrary(os.path.join(dir, libName))
 class testError(Exception):
     pass
 
+def _rune_to_int(value):
+    assert isinstance(value, str), "expected rune string"
+    assert len(value) == 1, "expected exactly one Unicode scalar value"
+    code = ord(value)
+    assert code < 0xD800 or code > 0xDFFF, "expected Unicode scalar value"
+    return code
+
+def _int_to_rune(value):
+    return chr(value)
+
 class SeqIterator(object):
     def __init__(self, seq):
         self.idx = 0
@@ -222,7 +232,7 @@ class SeqString(Structure):
         dll.test_seq_string_delete(self, index)
 
     def append(self, value):
-        dll.test_seq_string_add(self, value)
+        dll.test_seq_string_add(self, value.encode("utf8"))
 
     def clear(self):
         dll.test_seq_string_clear(self)

--- a/tests/pixie_python_checks.py
+++ b/tests/pixie_python_checks.py
@@ -127,9 +127,15 @@ def run(pixie):
     typeface = pixie.read_typeface(font_path)
     assert typeface.file_path.endswith("Inter-Regular.ttf")
     typeface.file_path = font_path
-    assert typeface.has_glyph(ord("A"))
-    assert typeface.get_advance(ord("A")) > 0
-    assert typeface.get_glyph_path(ord("A")).compute_bounds().w > 0
+    assert typeface.has_glyph("A")
+    assert typeface.get_advance("A") > 0
+    assert typeface.get_glyph_path("A").compute_bounds().w > 0
+    for invalid_rune in ("AB", "\ud800"):
+        try:
+            typeface.has_glyph(invalid_rune)
+        except AssertionError:
+            continue
+        raise AssertionError("invalid rune was accepted")
 
     font = typeface.new_font()
     font.size = 24

--- a/tests/pixie_python_checks.py
+++ b/tests/pixie_python_checks.py
@@ -1,0 +1,243 @@
+import os
+from pathlib import Path
+
+
+def pixie_root():
+    return Path(os.environ.get("PIXIE_ROOT", Path(__file__).resolve().parents[2] / "pixie"))
+
+
+def asset(*parts):
+    return str(pixie_root().joinpath(*parts))
+
+
+def approx(value, expected, eps=0.0001):
+    assert abs(value - expected) <= eps, f"expected {expected}, got {value}"
+
+
+def matrix_values(matrix):
+    return list(matrix.values)
+
+
+def run(pixie):
+    font_path = asset("tests", "fonts", "Inter-Regular.ttf")
+    image_path = asset("tests", "images", "turtle.png")
+    ppm = "P3\n2 1\n255\n255 0 0 0 255 0\n"
+
+    assert pixie.DEFAULT_MITER_LIMIT == 4.0
+    assert pixie.AUTO_LINE_HEIGHT == -1.0
+    assert pixie.PNG_FORMAT == 0
+    assert pixie.LINEAR_GRADIENT_PAINT == 3
+
+    red = pixie.parse_color("#ff0000")
+    green = pixie.parse_color("#00ff00")
+    mixed = pixie.mix(red, green, 0.25)
+    approx(mixed.r, 0.75)
+    approx(mixed.g, 0.25)
+
+    mat = pixie.translate(3, 4)
+    assert matrix_values(mat)[6] == 3
+    assert matrix_values(pixie.inverse(mat))[6] == -3
+    assert pixie.snap_to_pixels(pixie.Rect(1, 2, 3, 4)) == pixie.Rect(1, 2, 3, 4)
+    assert pixie.miter_limit_to_angle(2) > 0
+    assert pixie.angle_to_miter_limit(1) > 0
+
+    dashes = pixie.SeqFloat32()
+    dashes.append(1.5)
+    dashes.append(2.5)
+    dashes[1] = 3.5
+    assert len(dashes) == 2
+    approx(dashes[1], 3.5)
+
+    image = pixie.Image(4, 3)
+    assert image.width == 4
+    assert image.height == 3
+    assert len(image.encode_base64()) > 20
+    image.fill(red)
+    assert image.is_one_color()
+    assert image.is_opaque()
+    assert image.get_color(1, 1) == red
+    image.set_color(0, 0, green)
+    assert not image.is_one_color()
+    assert image.copy().width == image.width
+
+    solid = pixie.Paint(pixie.SOLID_PAINT)
+    solid.color = red
+    image.paint_fill(solid)
+    image.apply_opacity(0.5)
+    approx(image.get_color(0, 0).a, 0.5, 0.01)
+    image.invert()
+    image.blur(1, red)
+
+    resized = image.resize(6, 5)
+    assert resized.width == 6
+    assert resized.height == 5
+    resized.rotate90()
+    assert resized.width == 5
+    assert resized.height == 6
+    assert resized.sub_image(0, 0, 2, 2).width == 2
+    assert resized.rect_sub_image(pixie.Rect(0, 0, 1, 1)).height == 1
+    assert resized.shadow(pixie.Vector2(1, 2), 3, 4, red).width == resized.width
+    assert resized.super_image(-1, -1, resized.width + 2, resized.height + 2).width == resized.width + 2
+    assert resized.opaque_bounds().w > 0
+
+    paint = pixie.Paint(pixie.SOLID_PAINT)
+    paint.kind = pixie.LINEAR_GRADIENT_PAINT
+    paint.blend_mode = pixie.MULTIPLY_BLEND
+    paint.opacity = 0.5
+    paint.color = green
+    paint.image_mat = pixie.scale(2, 3)
+    assert paint.kind == pixie.LINEAR_GRADIENT_PAINT
+    approx(paint.opacity, 0.5)
+
+    paint.gradient_handle_positions.append(pixie.Vector2(0.25, 0.0))
+    paint.gradient_handle_positions.append(pixie.Vector2(0.75, 1.0))
+    paint.gradient_handle_positions[1] = pixie.Vector2(0.8, 1.0)
+    assert len(paint.gradient_handle_positions) == 2
+    approx(paint.gradient_handle_positions[1].x, 0.8)
+
+    paint.gradient_stops.append(pixie.ColorStop(red, 0.0))
+    paint.gradient_stops.append(pixie.ColorStop(green, 1.0))
+    assert len(paint.gradient_stops) == 2
+    assert paint.gradient_stops[1].color == green
+
+    path = pixie.Path()
+    path.move_to(1, 1)
+    path.line_to(2, 2)
+    path.bezier_curve_to(1, 2, 3, 4, 5, 6)
+    path.quadratic_curve_to(1, 2, 3, 4)
+    path.elliptical_arc_to(1, 2, 3, False, True, 4, 5)
+    path.arc(1, 2, 3, 0, 1, False)
+    path.arc_to(1, 2, 3, 4, 5)
+    path.rect(0, 0, 3, 4)
+    path.rounded_rect(0, 0, 3, 4, 1, 1, 1, 1, True)
+    path.ellipse(1, 2, 3, 4)
+    path.circle(1, 2, 3)
+    path.polygon(1, 2, 3, 5)
+    path.close_path()
+    assert path.compute_bounds().w > 0
+
+    rect_path = pixie.Path()
+    rect_path.rect(0, 0, 10, 10)
+    solid_dashes = pixie.SeqFloat32()
+    assert rect_path.fill_overlaps(pixie.Vector2(5, 5), None, pixie.NON_ZERO)
+    assert rect_path.stroke_overlaps(
+        pixie.Vector2(0, 5), None, 2, pixie.BUTT_CAP, pixie.MITER_JOIN, pixie.DEFAULT_MITER_LIMIT, solid_dashes
+    )
+
+    typeface = pixie.read_typeface(font_path)
+    assert typeface.file_path.endswith("Inter-Regular.ttf")
+    typeface.file_path = font_path
+    assert typeface.has_glyph(ord("A"))
+    assert typeface.get_advance(ord("A")) > 0
+    assert typeface.get_glyph_path(ord("A")).compute_bounds().w > 0
+
+    font = typeface.new_font()
+    font.size = 24
+    font.line_height = pixie.AUTO_LINE_HEIGHT
+    font.paint = solid
+    font.text_case = pixie.UPPER_CASE
+    font.underline = True
+    font.strikethrough = True
+    font.no_kerning_adjustments = True
+    font.paints.append(solid)
+    assert len(font.paints) >= 1
+    assert font.scale() > 0
+    assert font.default_line_height() > 0
+    assert font.layout_bounds("abcd").x > 0
+    assert font.typeset("abcd", pixie.Vector2(100, 100), pixie.LEFT_ALIGN, pixie.TOP_ALIGN, True).layout_bounds().x > 0
+
+    span = pixie.Span("hi", font)
+    span.text = "hello"
+    spans = pixie.SeqSpan()
+    spans.append(span)
+    arrangement = spans.typeset(pixie.Vector2(100, 100), pixie.CENTER_ALIGN, pixie.BOTTOM_ALIGN, True)
+    assert spans[0].text == "hello"
+    assert arrangement.layout_bounds().x > 0
+    assert spans.layout_bounds().y > 0
+    assert arrangement.compute_bounds(mat).x > 0
+
+    canvas = pixie.Image(64, 64)
+    canvas.fill(pixie.parse_color("#ffffff"))
+    canvas.fill_text(font, "abc", mat, pixie.Vector2(60, 60), pixie.LEFT_ALIGN, pixie.TOP_ALIGN)
+    canvas.arrangement_fill_text(arrangement, mat)
+    canvas.stroke_text(
+        font, "abc", mat, 2, pixie.Vector2(60, 60), pixie.LEFT_ALIGN, pixie.TOP_ALIGN,
+        pixie.BUTT_CAP, pixie.MITER_JOIN, pixie.DEFAULT_MITER_LIMIT, dashes
+    )
+    canvas.arrangement_stroke_text(arrangement, mat, 2, pixie.BUTT_CAP, pixie.MITER_JOIN, pixie.DEFAULT_MITER_LIMIT, dashes)
+    canvas.fill_path(rect_path, solid, mat, pixie.NON_ZERO)
+    canvas.stroke_path(rect_path, solid, mat, 2, pixie.BUTT_CAP, pixie.MITER_JOIN, pixie.DEFAULT_MITER_LIMIT, dashes)
+
+    ctx = pixie.Context(80, 80)
+    ctx.global_alpha = 0.75
+    ctx.line_width = 2
+    ctx.miter_limit = 5
+    ctx.line_cap = pixie.ROUND_CAP
+    ctx.line_join = pixie.BEVEL_JOIN
+    ctx.font = font_path
+    ctx.font_size = 24
+    ctx.text_align = pixie.RIGHT_ALIGN
+    assert ctx.text_align == pixie.RIGHT_ALIGN
+    assert ctx.measure_text("abcd").width > 0
+    ctx.set_transform(mat)
+    assert matrix_values(ctx.get_transform())[6] == 3
+    ctx.transform(pixie.scale(2, 2))
+    ctx.reset_transform()
+    ctx.set_line_dash(solid_dashes)
+    ctx.begin_path()
+    ctx.rect(0, 0, 10, 10)
+    assert ctx.is_point_in_path(5, 5, pixie.NON_ZERO)
+    assert ctx.path_is_point_in_path(rect_path, 5, 5, pixie.NON_ZERO)
+    assert ctx.is_point_in_stroke(0, 5)
+    assert ctx.path_is_point_in_stroke(rect_path, 0, 5)
+    ctx.set_line_dash(dashes)
+    assert len(ctx.get_line_dash()) == 2
+    ctx.move_to(1, 1)
+    ctx.line_to(2, 2)
+    ctx.bezier_curve_to(1, 2, 3, 4, 5, 6)
+    ctx.quadratic_curve_to(1, 2, 3, 4)
+    ctx.arc(1, 2, 3, 0, 1, False)
+    ctx.arc_to(1, 2, 3, 4, 5)
+    ctx.rounded_rect(0, 0, 3, 4, 1, 1, 1, 1)
+    ctx.ellipse(1, 2, 3, 4)
+    ctx.circle(1, 2, 3)
+    ctx.polygon(1, 2, 3, 5)
+    ctx.close_path()
+    ctx.fill(pixie.NON_ZERO)
+    ctx.path_fill(rect_path, pixie.EVEN_ODD)
+    ctx.clip(pixie.NON_ZERO)
+    ctx.path_clip(rect_path, pixie.EVEN_ODD)
+    ctx.stroke()
+    ctx.path_stroke(rect_path)
+    ctx.draw_image(canvas, 1, 2)
+    ctx.draw_image2(canvas, 1, 2, 3, 4)
+    ctx.draw_image3(canvas, 1, 2, 3, 4, 5, 6, 7, 8)
+    ctx.clear_rect(1, 2, 3, 4)
+    ctx.fill_rect(1, 2, 3, 4)
+    ctx.stroke_rect(1, 2, 3, 4)
+    ctx.stroke_segment(1, 2, 3, 4)
+    ctx.fill_text("abc", 1, 2)
+    ctx.stroke_text("abc", 1, 2)
+    ctx.translate(3, 4)
+    ctx.scale(2, 3)
+    ctx.rotate(0.5)
+    ctx.save()
+    ctx.save_layer()
+    ctx.restore()
+
+    decoded = pixie.decode_base64(canvas.encode_base64())
+    assert decoded.width == canvas.width
+    assert decoded.height == canvas.height
+    assert pixie.decode_image(ppm).width == 2
+    assert pixie.decode_image_dimensions(ppm).height == 1
+    assert pixie.read_image(image_path).width == 40
+    assert pixie.read_image_dimensions(image_path).height == 40
+    assert pixie.read_font(font_path).size == 12
+    assert pixie.parse_path("M0 0 L10 0 L10 10 Z").compute_bounds().w == 10
+
+    try:
+        pixie.parse_color("bad")
+    except pixie.PixieError as exc:
+        assert "bad" in str(exc)
+    else:
+        raise AssertionError("parse_color should raise on invalid colors")

--- a/tests/pixie_python_checks.py
+++ b/tests/pixie_python_checks.py
@@ -36,6 +36,7 @@ def run(pixie):
 
     mat = pixie.translate(3, 4)
     assert matrix_values(mat)[6] == 3
+    assert matrix_values(pixie.inverse(mat))[6] == -3
     assert pixie.snap_to_pixels(pixie.Rect(1, 2, 3, 4)) == pixie.Rect(1, 2, 3, 4)
     assert pixie.miter_limit_to_angle(2) > 0
     assert pixie.angle_to_miter_limit(1) > 0

--- a/tests/pixie_python_checks.py
+++ b/tests/pixie_python_checks.py
@@ -36,7 +36,6 @@ def run(pixie):
 
     mat = pixie.translate(3, 4)
     assert matrix_values(mat)[6] == 3
-    assert matrix_values(pixie.inverse(mat))[6] == -3
     assert pixie.snap_to_pixels(pixie.Rect(1, 2, 3, 4)) == pixie.Rect(1, 2, 3, 4)
     assert pixie.miter_limit_to_angle(2) > 0
     assert pixie.angle_to_miter_limit(1) > 0

--- a/tests/test_pixie_c.c
+++ b/tests/test_pixie_c.c
@@ -1,0 +1,244 @@
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include "pixie.h"
+
+#ifndef PIXIE_ROOT
+#define PIXIE_ROOT "../pixie"
+#endif
+
+#define FONT_PATH PIXIE_ROOT "/tests/fonts/Inter-Regular.ttf"
+#define IMAGE_PATH PIXIE_ROOT "/tests/images/turtle.png"
+
+static void approx(float value, float expected) {
+    assert(fabsf(value - expected) < 0.0001f);
+}
+
+static void approx_eps(float value, float expected, float eps) {
+    assert(fabsf(value - expected) <= eps);
+}
+
+static void assert_color(Color actual, Color expected) {
+    approx(actual.r, expected.r);
+    approx(actual.g, expected.g);
+    approx(actual.b, expected.b);
+    approx(actual.a, expected.a);
+}
+
+int main() {
+    const char *ppm = "P3\n2 1\n255\n255 0 0 0 255 0\n";
+
+    assert(DEFAULT_MITER_LIMIT == 4.0f);
+    assert(AUTO_LINE_HEIGHT == -1.0f);
+    assert(PNG_FORMAT == 0);
+    assert(LINEAR_GRADIENT_PAINT == 3);
+
+    Color red = pixie_parse_color("#ff0000");
+    Color green = pixie_parse_color("#00ff00");
+    Color mixed = pixie_mix(red, green, 0.25f);
+    approx(mixed.r, 0.75f);
+    approx(mixed.g, 0.25f);
+
+    Matrix3 mat = pixie_translate(3, 4);
+    Matrix3 identity = pixie_translate(0, 0);
+    assert(mat.values[6] == 3);
+    assert(pixie_inverse(mat).values[6] == -3);
+    assert(pixie_rect_eq(pixie_snap_to_pixels(pixie_rect(1, 2, 3, 4)), pixie_rect(1, 2, 3, 4)));
+    assert(pixie_miter_limit_to_angle(2) > 0);
+    assert(pixie_angle_to_miter_limit(1) > 0);
+
+    SeqFloat32 dashes = pixie_new_seq_float32();
+    pixie_seq_float32_add(dashes, 1.5f);
+    pixie_seq_float32_add(dashes, 2.5f);
+    pixie_seq_float32_set(dashes, 1, 3.5f);
+    assert(pixie_seq_float32_len(dashes) == 2);
+    approx(pixie_seq_float32_get(dashes, 1), 3.5f);
+
+    Image image = pixie_new_image(4, 3);
+    assert(pixie_image_get_width(image) == 4);
+    assert(pixie_image_get_height(image) == 3);
+    assert(strlen(pixie_image_encode_base64(image)) > 20);
+    pixie_image_fill(image, red);
+    assert(pixie_image_is_one_color(image));
+    assert(pixie_image_is_opaque(image));
+    assert_color(pixie_image_get_color(image, 1, 1), red);
+    pixie_image_set_color(image, 0, 0, green);
+    assert(!pixie_image_is_one_color(image));
+    Image image_copy = pixie_image_copy(image);
+    assert(pixie_image_get_width(image_copy) == pixie_image_get_width(image));
+
+    Paint solid = pixie_new_paint(SOLID_PAINT);
+    pixie_paint_set_color(solid, red);
+    pixie_image_paint_fill(image, solid);
+    pixie_image_apply_opacity(image, 0.5f);
+    approx_eps(pixie_image_get_color(image, 0, 0).a, 0.5f, 0.01f);
+    pixie_image_invert(image);
+    pixie_image_blur(image, 1, red);
+
+    Image resized = pixie_image_resize(image, 6, 5);
+    assert(pixie_image_get_width(resized) == 6);
+    assert(pixie_image_get_height(resized) == 5);
+    pixie_image_rotate90(resized);
+    assert(pixie_image_get_width(resized) == 5);
+    assert(pixie_image_get_height(resized) == 6);
+    assert(pixie_image_get_width(pixie_image_sub_image(resized, 0, 0, 2, 2)) == 2);
+    assert(pixie_image_get_height(pixie_image_rect_sub_image(resized, pixie_rect(0, 0, 1, 1))) == 1);
+    assert(pixie_image_get_width(pixie_image_shadow(resized, pixie_vector2(1, 2), 3, 4, red)) == pixie_image_get_width(resized));
+    assert(pixie_image_get_width(pixie_image_super_image(resized, -1, -1, pixie_image_get_width(resized) + 2, pixie_image_get_height(resized) + 2)) == pixie_image_get_width(resized) + 2);
+    assert(pixie_image_opaque_bounds(resized).w > 0);
+
+    Paint paint = pixie_new_paint(SOLID_PAINT);
+    pixie_paint_set_kind(paint, LINEAR_GRADIENT_PAINT);
+    pixie_paint_set_blend_mode(paint, MULTIPLY_BLEND);
+    pixie_paint_set_opacity(paint, 0.5f);
+    pixie_paint_set_color(paint, green);
+    pixie_paint_set_image_mat(paint, pixie_scale(2, 3));
+    assert(pixie_paint_get_kind(paint) == LINEAR_GRADIENT_PAINT);
+    approx(pixie_paint_get_opacity(paint), 0.5f);
+    pixie_paint_gradient_handle_positions_add(paint, pixie_vector2(0.25f, 0));
+    pixie_paint_gradient_handle_positions_add(paint, pixie_vector2(0.75f, 1));
+    pixie_paint_gradient_handle_positions_set(paint, 1, pixie_vector2(0.8f, 1));
+    assert(pixie_paint_gradient_handle_positions_len(paint) == 2);
+    approx(pixie_paint_gradient_handle_positions_get(paint, 1).x, 0.8f);
+    pixie_paint_gradient_stops_add(paint, pixie_color_stop(red, 0));
+    pixie_paint_gradient_stops_add(paint, pixie_color_stop(green, 1));
+    assert(pixie_paint_gradient_stops_len(paint) == 2);
+    assert_color(pixie_paint_gradient_stops_get(paint, 1).color, green);
+
+    Path path = pixie_new_path();
+    pixie_path_move_to(path, 1, 1);
+    pixie_path_line_to(path, 2, 2);
+    pixie_path_bezier_curve_to(path, 1, 2, 3, 4, 5, 6);
+    pixie_path_quadratic_curve_to(path, 1, 2, 3, 4);
+    pixie_path_elliptical_arc_to(path, 1, 2, 3, 0, 1, 4, 5);
+    pixie_path_arc(path, 1, 2, 3, 0, 1, 0);
+    pixie_path_arc_to(path, 1, 2, 3, 4, 5);
+    pixie_path_rect(path, 0, 0, 3, 4, 1);
+    pixie_path_rounded_rect(path, 0, 0, 3, 4, 1, 1, 1, 1, 1);
+    pixie_path_ellipse(path, 1, 2, 3, 4);
+    pixie_path_circle(path, 1, 2, 3);
+    pixie_path_polygon(path, 1, 2, 3, 5);
+    pixie_path_close_path(path);
+    assert(pixie_path_compute_bounds(path, identity).w > 0);
+
+    Path rect_path = pixie_new_path();
+    pixie_path_rect(rect_path, 0, 0, 10, 10, 1);
+    SeqFloat32 solid_dashes = pixie_new_seq_float32();
+    assert(pixie_path_fill_overlaps(rect_path, pixie_vector2(5, 5), identity, NON_ZERO));
+    assert(pixie_path_stroke_overlaps(rect_path, pixie_vector2(0, 5), identity, 2, BUTT_CAP, MITER_JOIN, DEFAULT_MITER_LIMIT, solid_dashes));
+
+    Typeface typeface = pixie_read_typeface(FONT_PATH);
+    assert(strstr(pixie_typeface_get_file_path(typeface), "Inter-Regular.ttf") != NULL);
+    pixie_typeface_set_file_path(typeface, FONT_PATH);
+    assert(pixie_typeface_has_glyph(typeface, 'A'));
+    assert(pixie_typeface_get_advance(typeface, 'A') > 0);
+    assert(pixie_path_compute_bounds(pixie_typeface_get_glyph_path(typeface, 'A'), identity).w > 0);
+
+    Font font = pixie_typeface_new_font(typeface);
+    pixie_font_set_size(font, 24);
+    pixie_font_set_line_height(font, AUTO_LINE_HEIGHT);
+    pixie_font_set_paint(font, solid);
+    pixie_font_set_text_case(font, UPPER_CASE);
+    pixie_font_set_underline(font, 1);
+    pixie_font_set_strikethrough(font, 1);
+    pixie_font_set_no_kerning_adjustments(font, 1);
+    pixie_font_paints_add(font, solid);
+    assert(pixie_font_paints_len(font) >= 1);
+    assert(pixie_font_scale(font) > 0);
+    assert(pixie_font_default_line_height(font) > 0);
+    assert(pixie_font_layout_bounds(font, "abcd").x > 0);
+    assert(pixie_arrangement_layout_bounds(pixie_font_typeset(font, "abcd", pixie_vector2(100, 100), LEFT_ALIGN, TOP_ALIGN, 1)).x > 0);
+
+    Span span = pixie_new_span("hi", font);
+    pixie_span_set_text(span, "hello");
+    SeqSpan spans = pixie_new_seq_span();
+    pixie_seq_span_add(spans, span);
+    Arrangement arrangement = pixie_seq_span_typeset(spans, pixie_vector2(100, 100), CENTER_ALIGN, BOTTOM_ALIGN, 1);
+    assert(strcmp(pixie_span_get_text(pixie_seq_span_get(spans, 0)), "hello") == 0);
+    assert(pixie_arrangement_layout_bounds(arrangement).x > 0);
+    assert(pixie_seq_span_layout_bounds(spans).y > 0);
+    assert(pixie_arrangement_compute_bounds(arrangement, mat).x > 0);
+
+    Image canvas = pixie_new_image(64, 64);
+    pixie_image_fill(canvas, pixie_parse_color("#ffffff"));
+    pixie_image_fill_text(canvas, font, "abc", mat, pixie_vector2(60, 60), LEFT_ALIGN, TOP_ALIGN);
+    pixie_image_arrangement_fill_text(canvas, arrangement, mat);
+    pixie_image_stroke_text(canvas, font, "abc", mat, 2, pixie_vector2(60, 60), LEFT_ALIGN, TOP_ALIGN, BUTT_CAP, MITER_JOIN, DEFAULT_MITER_LIMIT, dashes);
+    pixie_image_arrangement_stroke_text(canvas, arrangement, mat, 2, BUTT_CAP, MITER_JOIN, DEFAULT_MITER_LIMIT, dashes);
+    pixie_image_fill_path(canvas, rect_path, solid, mat, NON_ZERO);
+    pixie_image_stroke_path(canvas, rect_path, solid, mat, 2, BUTT_CAP, MITER_JOIN, DEFAULT_MITER_LIMIT, dashes);
+
+    Context ctx = pixie_new_context(80, 80);
+    pixie_context_set_global_alpha(ctx, 0.75f);
+    pixie_context_set_line_width(ctx, 2);
+    pixie_context_set_miter_limit(ctx, 5);
+    pixie_context_set_line_cap(ctx, ROUND_CAP);
+    pixie_context_set_line_join(ctx, BEVEL_JOIN);
+    pixie_context_set_font(ctx, FONT_PATH);
+    pixie_context_set_font_size(ctx, 24);
+    pixie_context_set_text_align(ctx, RIGHT_ALIGN);
+    assert(pixie_context_get_text_align(ctx) == RIGHT_ALIGN);
+    assert(pixie_context_measure_text(ctx, "abcd").width > 0);
+    pixie_context_set_transform(ctx, mat);
+    assert(pixie_context_get_transform(ctx).values[6] == 3);
+    pixie_context_transform(ctx, pixie_scale(2, 2));
+    pixie_context_reset_transform(ctx);
+    pixie_context_set_line_dash(ctx, solid_dashes);
+    pixie_context_begin_path(ctx);
+    pixie_context_rect(ctx, 0, 0, 10, 10);
+    assert(pixie_context_is_point_in_path(ctx, 5, 5, NON_ZERO));
+    assert(pixie_context_path_is_point_in_path(ctx, rect_path, 5, 5, NON_ZERO));
+    assert(pixie_context_is_point_in_stroke(ctx, 0, 5));
+    assert(pixie_context_path_is_point_in_stroke(ctx, rect_path, 0, 5));
+    pixie_context_set_line_dash(ctx, dashes);
+    assert(pixie_seq_float32_len(pixie_context_get_line_dash(ctx)) == 2);
+    pixie_context_move_to(ctx, 1, 1);
+    pixie_context_line_to(ctx, 2, 2);
+    pixie_context_bezier_curve_to(ctx, 1, 2, 3, 4, 5, 6);
+    pixie_context_quadratic_curve_to(ctx, 1, 2, 3, 4);
+    pixie_context_arc(ctx, 1, 2, 3, 0, 1, 0);
+    pixie_context_arc_to(ctx, 1, 2, 3, 4, 5);
+    pixie_context_rounded_rect(ctx, 0, 0, 3, 4, 1, 1, 1, 1);
+    pixie_context_ellipse(ctx, 1, 2, 3, 4);
+    pixie_context_circle(ctx, 1, 2, 3);
+    pixie_context_polygon(ctx, 1, 2, 3, 5);
+    pixie_context_close_path(ctx);
+    pixie_context_fill(ctx, NON_ZERO);
+    pixie_context_path_fill(ctx, rect_path, EVEN_ODD);
+    pixie_context_clip(ctx, NON_ZERO);
+    pixie_context_path_clip(ctx, rect_path, EVEN_ODD);
+    pixie_context_stroke(ctx);
+    pixie_context_path_stroke(ctx, rect_path);
+    pixie_context_draw_image(ctx, canvas, 1, 2);
+    pixie_context_draw_image2(ctx, canvas, 1, 2, 3, 4);
+    pixie_context_draw_image3(ctx, canvas, 1, 2, 3, 4, 5, 6, 7, 8);
+    pixie_context_clear_rect(ctx, 1, 2, 3, 4);
+    pixie_context_fill_rect(ctx, 1, 2, 3, 4);
+    pixie_context_stroke_rect(ctx, 1, 2, 3, 4);
+    pixie_context_stroke_segment(ctx, 1, 2, 3, 4);
+    pixie_context_fill_text(ctx, "abc", 1, 2);
+    pixie_context_stroke_text(ctx, "abc", 1, 2);
+    pixie_context_translate(ctx, 3, 4);
+    pixie_context_scale(ctx, 2, 3);
+    pixie_context_rotate(ctx, 0.5f);
+    pixie_context_save(ctx);
+    pixie_context_save_layer(ctx);
+    pixie_context_restore(ctx);
+
+    Image decoded = pixie_decode_base64(pixie_image_encode_base64(canvas));
+    assert(pixie_image_get_width(decoded) == pixie_image_get_width(canvas));
+    assert(pixie_image_get_height(decoded) == pixie_image_get_height(canvas));
+    assert(pixie_image_get_width(pixie_decode_image((char*)ppm)) == 2);
+    assert(pixie_decode_image_dimensions((char*)ppm).height == 1);
+    assert(pixie_image_get_width(pixie_read_image(IMAGE_PATH)) == 40);
+    assert(pixie_read_image_dimensions(IMAGE_PATH).height == 40);
+    approx(pixie_font_get_size(pixie_read_font(FONT_PATH)), 12);
+    assert(pixie_path_compute_bounds(pixie_parse_path("M0 0 L10 0 L10 10 Z"), identity).w == 10);
+    pixie_parse_color("bad");
+    assert(pixie_check_error());
+    assert(strstr(pixie_take_error(), "bad") != NULL);
+
+    printf("All Pixie C tests passed!\n");
+    return 0;
+}

--- a/tests/test_pixie_c.c
+++ b/tests/test_pixie_c.c
@@ -43,6 +43,7 @@ int main() {
     Matrix3 mat = pixie_translate(3, 4);
     Matrix3 identity = pixie_translate(0, 0);
     assert(mat.values[6] == 3);
+    assert(pixie_inverse(mat).values[6] == -3);
     assert(pixie_rect_eq(pixie_snap_to_pixels(pixie_rect(1, 2, 3, 4)), pixie_rect(1, 2, 3, 4)));
     assert(pixie_miter_limit_to_angle(2) > 0);
     assert(pixie_angle_to_miter_limit(1) > 0);

--- a/tests/test_pixie_c.c
+++ b/tests/test_pixie_c.c
@@ -43,7 +43,6 @@ int main() {
     Matrix3 mat = pixie_translate(3, 4);
     Matrix3 identity = pixie_translate(0, 0);
     assert(mat.values[6] == 3);
-    assert(pixie_inverse(mat).values[6] == -3);
     assert(pixie_rect_eq(pixie_snap_to_pixels(pixie_rect(1, 2, 3, 4)), pixie_rect(1, 2, 3, 4)));
     assert(pixie_miter_limit_to_angle(2) > 0);
     assert(pixie_angle_to_miter_limit(1) > 0);

--- a/tests/test_pixie_cpp.cpp
+++ b/tests/test_pixie_cpp.cpp
@@ -1,0 +1,240 @@
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include "pixie.hpp"
+
+#ifndef PIXIE_ROOT
+#define PIXIE_ROOT "../pixie"
+#endif
+
+#define FONT_PATH PIXIE_ROOT "/tests/fonts/Inter-Regular.ttf"
+#define IMAGE_PATH PIXIE_ROOT "/tests/images/turtle.png"
+
+static void approx(float value, float expected, float eps = 0.0001f) {
+    assert(std::fabs(value - expected) <= eps);
+}
+
+static void assertColor(Color actual, Color expected) {
+    approx(actual.r, expected.r);
+    approx(actual.g, expected.g);
+    approx(actual.b, expected.b);
+    approx(actual.a, expected.a);
+}
+
+int main() {
+    const char *ppm = "P3\n2 1\n255\n255 0 0 0 255 0\n";
+
+    assert(DEFAULT_MITER_LIMIT == 4.0f);
+    assert(AUTO_LINE_HEIGHT == -1.0f);
+    assert(PNG_FORMAT == 0);
+    assert(LINEAR_GRADIENT_PAINT == 3);
+
+    Color red = parseColor("#ff0000");
+    Color green = parseColor("#00ff00");
+    Color mixed = mix(red, green, 0.25f);
+    approx(mixed.r, 0.75f);
+    approx(mixed.g, 0.25f);
+
+    Matrix3 mat = translate(3, 4);
+    Matrix3 identity = translate(0, 0);
+    assert(mat.values[6] == 3);
+    assert(inverse(mat).values[6] == -3);
+    assert(pixie_rect_eq(snapToPixels(rect(1, 2, 3, 4)), rect(1, 2, 3, 4)));
+    assert(miterLimitToAngle(2) > 0);
+    assert(angleToMiterLimit(1) > 0);
+
+    SeqFloat32 dashes = pixie_new_seq_float32();
+    pixie_seq_float32_add(dashes, 1.5f);
+    pixie_seq_float32_add(dashes, 2.5f);
+    pixie_seq_float32_set(dashes, 1, 3.5f);
+    assert(pixie_seq_float32_len(dashes) == 2);
+    approx(pixie_seq_float32_get(dashes, 1), 3.5f);
+
+    Image image(4, 3);
+    assert(image.getWidth() == 4);
+    assert(image.getHeight() == 3);
+    assert(std::strlen(image.encodeBase64()) > 20);
+    image.fill(red);
+    assert(image.isOneColor());
+    assert(image.isOpaque());
+    assertColor(image.getColor(1, 1), red);
+    image.setColor(0, 0, green);
+    assert(!image.isOneColor());
+    assert(image.copy().getWidth() == image.getWidth());
+
+    Paint solid(SOLID_PAINT);
+    solid.setColor(red);
+    image.fill(solid);
+    image.applyOpacity(0.5f);
+    approx(image.getColor(0, 0).a, 0.5f, 0.01f);
+    image.invert();
+    image.blur(1, red);
+
+    Image resized = image.resize(6, 5);
+    assert(resized.getWidth() == 6);
+    assert(resized.getHeight() == 5);
+    resized.rotate90();
+    assert(resized.getWidth() == 5);
+    assert(resized.getHeight() == 6);
+    assert(resized.subImage(0, 0, 2, 2).getWidth() == 2);
+    assert(resized.subImage(rect(0, 0, 1, 1)).getHeight() == 1);
+    assert(resized.shadow(vector2(1, 2), 3, 4, red).getWidth() == resized.getWidth());
+    assert(resized.superImage(-1, -1, resized.getWidth() + 2, resized.getHeight() + 2).getWidth() == resized.getWidth() + 2);
+    assert(resized.opaqueBounds().w > 0);
+
+    Paint paint(SOLID_PAINT);
+    paint.setKind(LINEAR_GRADIENT_PAINT);
+    paint.setBlendMode(MULTIPLY_BLEND);
+    paint.setOpacity(0.5f);
+    paint.setColor(green);
+    paint.setImageMat(scale(2, 3));
+    assert(paint.getKind() == LINEAR_GRADIENT_PAINT);
+    approx(paint.getOpacity(), 0.5f);
+    pixie_paint_gradient_handle_positions_add(paint, vector2(0.25f, 0));
+    pixie_paint_gradient_handle_positions_add(paint, vector2(0.75f, 1));
+    pixie_paint_gradient_handle_positions_set(paint, 1, vector2(0.8f, 1));
+    assert(pixie_paint_gradient_handle_positions_len(paint) == 2);
+    approx(pixie_paint_gradient_handle_positions_get(paint, 1).x, 0.8f);
+    pixie_paint_gradient_stops_add(paint, colorStop(red, 0));
+    pixie_paint_gradient_stops_add(paint, colorStop(green, 1));
+    assert(pixie_paint_gradient_stops_len(paint) == 2);
+    assertColor(pixie_paint_gradient_stops_get(paint, 1).color, green);
+
+    Path path;
+    path.moveTo(1, 1);
+    path.lineTo(2, 2);
+    path.bezierCurveTo(1, 2, 3, 4, 5, 6);
+    path.quadraticCurveTo(1, 2, 3, 4);
+    path.ellipticalArcTo(1, 2, 3, false, true, 4, 5);
+    path.arc(1, 2, 3, 0, 1, false);
+    path.arcTo(1, 2, 3, 4, 5);
+    path.rect(0, 0, 3, 4, true);
+    path.roundedRect(0, 0, 3, 4, 1, 1, 1, 1, true);
+    path.ellipse(1, 2, 3, 4);
+    path.circle(1, 2, 3);
+    path.polygon(1, 2, 3, 5);
+    path.closePath();
+    assert(path.computeBounds(identity).w > 0);
+
+    Path rectPath;
+    rectPath.rect(0, 0, 10, 10, true);
+    SeqFloat32 solidDashes = pixie_new_seq_float32();
+    assert(rectPath.fillOverlaps(vector2(5, 5), identity, NON_ZERO));
+    assert(rectPath.strokeOverlaps(vector2(0, 5), identity, 2, BUTT_CAP, MITER_JOIN, DEFAULT_MITER_LIMIT, solidDashes));
+
+    Typeface typeface = readTypeface(FONT_PATH);
+    assert(std::strstr(typeface.getFilePath(), "Inter-Regular.ttf") != nullptr);
+    typeface.setFilePath(FONT_PATH);
+    assert(typeface.hasGlyph('A'));
+    assert(typeface.getAdvance('A') > 0);
+    assert(typeface.getGlyphPath('A').computeBounds(identity).w > 0);
+
+    Font font = typeface.newFont();
+    font.setSize(24);
+    font.setLineHeight(AUTO_LINE_HEIGHT);
+    font.setPaint(solid);
+    font.setTextCase(UPPER_CASE);
+    font.setUnderline(true);
+    font.setStrikethrough(true);
+    font.setNoKerningAdjustments(true);
+    pixie_font_paints_add(font, solid);
+    assert(pixie_font_paints_len(font) >= 1);
+    assert(font.scale() > 0);
+    assert(font.defaultLineHeight() > 0);
+    assert(font.layoutBounds("abcd").x > 0);
+    assert(font.typeset("abcd", vector2(100, 100), LEFT_ALIGN, TOP_ALIGN, true).layoutBounds().x > 0);
+
+    Span span("hi", font);
+    span.setText("hello");
+    SeqSpan spans = pixie_new_seq_span();
+    pixie_seq_span_add(spans, span);
+    Arrangement arrangement = spans.typeset(vector2(100, 100), CENTER_ALIGN, BOTTOM_ALIGN, true);
+    assert(std::strcmp(pixie_seq_span_get(spans, 0).getText(), "hello") == 0);
+    assert(arrangement.layoutBounds().x > 0);
+    assert(spans.layoutBounds().y > 0);
+    assert(arrangement.computeBounds(mat).x > 0);
+
+    Image canvas(64, 64);
+    canvas.fill(parseColor("#ffffff"));
+    canvas.fillText(font, "abc", mat, vector2(60, 60), LEFT_ALIGN, TOP_ALIGN);
+    canvas.fillText(arrangement, mat);
+    canvas.strokeText(font, "abc", mat, 2, vector2(60, 60), LEFT_ALIGN, TOP_ALIGN, BUTT_CAP, MITER_JOIN, DEFAULT_MITER_LIMIT, dashes);
+    canvas.strokeText(arrangement, mat, 2, BUTT_CAP, MITER_JOIN, DEFAULT_MITER_LIMIT, dashes);
+    canvas.fillPath(rectPath, solid, mat, NON_ZERO);
+    canvas.strokePath(rectPath, solid, mat, 2, BUTT_CAP, MITER_JOIN, DEFAULT_MITER_LIMIT, dashes);
+
+    Context ctx(80, 80);
+    ctx.setGlobalAlpha(0.75f);
+    ctx.setLineWidth(2);
+    ctx.setMiterLimit(5);
+    ctx.setLineCap(ROUND_CAP);
+    ctx.setLineJoin(BEVEL_JOIN);
+    ctx.setFont(FONT_PATH);
+    ctx.setFontSize(24);
+    ctx.setTextAlign(RIGHT_ALIGN);
+    assert(ctx.getTextAlign() == RIGHT_ALIGN);
+    assert(ctx.measureText("abcd").width > 0);
+    ctx.setTransform(mat);
+    assert(ctx.getTransform().values[6] == 3);
+    ctx.transform(scale(2, 2));
+    ctx.resetTransform();
+    ctx.setLineDash(solidDashes);
+    ctx.beginPath();
+    ctx.rect(0, 0, 10, 10);
+    assert(ctx.isPointInPath(5, 5, NON_ZERO));
+    assert(ctx.isPointInPath(rectPath, 5, 5, NON_ZERO));
+    assert(ctx.isPointInStroke(0, 5));
+    assert(ctx.isPointInStroke(rectPath, 0, 5));
+    ctx.setLineDash(dashes);
+    SeqFloat32 ctxDashes = ctx.getLineDash();
+    assert(pixie_seq_float32_len(ctxDashes) == 2);
+    ctx.moveTo(1, 1);
+    ctx.lineTo(2, 2);
+    ctx.bezierCurveTo(1, 2, 3, 4, 5, 6);
+    ctx.quadraticCurveTo(1, 2, 3, 4);
+    ctx.arc(1, 2, 3, 0, 1, false);
+    ctx.arcTo(1, 2, 3, 4, 5);
+    ctx.roundedRect(0, 0, 3, 4, 1, 1, 1, 1);
+    ctx.ellipse(1, 2, 3, 4);
+    ctx.circle(1, 2, 3);
+    ctx.polygon(1, 2, 3, 5);
+    ctx.closePath();
+    ctx.fill(NON_ZERO);
+    ctx.fill(rectPath, EVEN_ODD);
+    ctx.clip(NON_ZERO);
+    ctx.clip(rectPath, EVEN_ODD);
+    ctx.stroke();
+    ctx.stroke(rectPath);
+    ctx.drawImage(canvas, 1, 2);
+    ctx.drawImage2(canvas, 1, 2, 3, 4);
+    ctx.drawImage3(canvas, 1, 2, 3, 4, 5, 6, 7, 8);
+    ctx.clearRect(1, 2, 3, 4);
+    ctx.fillRect(1, 2, 3, 4);
+    ctx.strokeRect(1, 2, 3, 4);
+    ctx.strokeSegment(1, 2, 3, 4);
+    ctx.fillText("abc", 1, 2);
+    ctx.strokeText("abc", 1, 2);
+    ctx.translate(3, 4);
+    ctx.scale(2, 3);
+    ctx.rotate(0.5f);
+    ctx.save();
+    ctx.saveLayer();
+    ctx.restore();
+
+    Image decoded = decodeBase64(canvas.encodeBase64());
+    assert(decoded.getWidth() == canvas.getWidth());
+    assert(decoded.getHeight() == canvas.getHeight());
+    assert(decodeImage(ppm).getWidth() == 2);
+    assert(decodeImageDimensions(ppm).height == 1);
+    assert(readImage(IMAGE_PATH).getWidth() == 40);
+    assert(readImageDimensions(IMAGE_PATH).height == 40);
+    approx(readFont(FONT_PATH).getSize(), 12);
+    assert(parsePath("M0 0 L10 0 L10 10 Z").computeBounds(identity).w == 10);
+    parseColor("bad");
+    assert(checkError());
+    assert(std::strstr(takeError(), "bad") != nullptr);
+
+    std::cout << "All Pixie C++ tests passed!" << std::endl;
+    return 0;
+}

--- a/tests/test_pixie_cpp.cpp
+++ b/tests/test_pixie_cpp.cpp
@@ -39,6 +39,7 @@ int main() {
     Matrix3 mat = translate(3, 4);
     Matrix3 identity = translate(0, 0);
     assert(mat.values[6] == 3);
+    assert(inverse(mat).values[6] == -3);
     assert(pixie_rect_eq(snapToPixels(rect(1, 2, 3, 4)), rect(1, 2, 3, 4)));
     assert(miterLimitToAngle(2) > 0);
     assert(angleToMiterLimit(1) > 0);

--- a/tests/test_pixie_cpp.cpp
+++ b/tests/test_pixie_cpp.cpp
@@ -39,7 +39,6 @@ int main() {
     Matrix3 mat = translate(3, 4);
     Matrix3 identity = translate(0, 0);
     assert(mat.values[6] == 3);
-    assert(inverse(mat).values[6] == -3);
     assert(pixie_rect_eq(snapToPixels(rect(1, 2, 3, 4)), rect(1, 2, 3, 4)));
     assert(miterLimitToAngle(2) > 0);
     assert(angleToMiterLimit(1) > 0);

--- a/tests/test_pixie_cpp.cpp
+++ b/tests/test_pixie_cpp.cpp
@@ -126,9 +126,9 @@ int main() {
     Typeface typeface = readTypeface(FONT_PATH);
     assert(std::strstr(typeface.getFilePath(), "Inter-Regular.ttf") != nullptr);
     typeface.setFilePath(FONT_PATH);
-    assert(typeface.hasGlyph('A'));
-    assert(typeface.getAdvance('A') > 0);
-    assert(typeface.getGlyphPath('A').computeBounds(identity).w > 0);
+    assert(typeface.hasGlyph(U'A'));
+    assert(typeface.getAdvance(U'A') > 0);
+    assert(typeface.getGlyphPath(U'A').computeBounds(identity).w > 0);
 
     Font font = typeface.newFont();
     font.setSize(24);

--- a/tests/test_pixie_nim.nim
+++ b/tests/test_pixie_nim.nim
@@ -1,0 +1,223 @@
+import os, strutils
+import ../../pixie/bindings/generated/pixie
+
+proc approx(value, expected: float32; eps: float32 = 0.0001) =
+  doAssert abs(value - expected) <= eps
+
+let
+  pixieRoot = getEnv("PIXIE_ROOT", "../pixie")
+  fontPath = pixieRoot / "tests" / "fonts" / "Inter-Regular.ttf"
+  imagePath = pixieRoot / "tests" / "images" / "turtle.png"
+  ppm = "P3\n2 1\n255\n255 0 0 0 255 0\n"
+
+doAssert defaultMiterLimit == 4.0
+doAssert autoLineHeight == -1.0
+doAssert PngFormat.ord == 0
+doAssert LinearGradientPaint.ord == 3
+
+let
+  red = parseColor("#ff0000")
+  green = parseColor("#00ff00")
+
+let
+  mat = translate(3, 4)
+  identity = translate(0, 0)
+doAssert mat.values[6] == 3
+doAssert inverse(mat).values[6] == -3
+doAssert snapToPixels(rect(1, 2, 3, 4)) == rect(1, 2, 3, 4)
+doAssert miterLimitToAngle(2) > 0
+doAssert angleToMiterLimit(1) > 0
+
+let dashes = newSeqFloat32()
+dashes.add(1.5)
+dashes.add(2.5)
+dashes[1] = 3.5
+doAssert dashes.len == 2
+approx(dashes[1], 3.5)
+
+let image = newImage(4, 3)
+doAssert image.width == 4
+doAssert image.height == 3
+doAssert ($image.encodeBase64()).len > 20
+image.fill(red)
+doAssert image.isOneColor()
+doAssert image.isOpaque()
+doAssert image.getColor(1, 1) == red
+image.setColor(0, 0, green)
+doAssert not image.isOneColor()
+doAssert image.copy().width == image.width
+
+let solid = newPaint(SolidPaint)
+solid.color = red
+image.fill(solid)
+image.applyOpacity(0.5)
+approx(image.getColor(0, 0).a, 0.5, 0.01)
+image.invert()
+image.blur(1, red)
+
+let resized = image.resize(6, 5)
+doAssert resized.width == 6
+doAssert resized.height == 5
+resized.rotate90()
+doAssert resized.width == 5
+doAssert resized.height == 6
+doAssert resized.subImage(0, 0, 2, 2).width == 2
+doAssert resized.subImage(rect(0, 0, 1, 1)).height == 1
+doAssert resized.shadow(vector2(1, 2), 3, 4, red).width == resized.width
+doAssert resized.superImage(-1, -1, resized.width + 2, resized.height + 2).width == resized.width + 2
+doAssert resized.opaqueBounds().w > 0
+
+let paint = newPaint(SolidPaint)
+paint.kind = LinearGradientPaint
+paint.blendMode = MultiplyBlend
+paint.opacity = 0.5
+paint.color = green
+paint.imageMat = scale(2, 3)
+doAssert paint.kind == LinearGradientPaint
+approx(paint.opacity, 0.5)
+paint.gradientHandlePositions.add(vector2(0.25, 0))
+paint.gradientHandlePositions.add(vector2(0.75, 1))
+paint.gradientHandlePositions[1] = vector2(0.8, 1)
+doAssert paint.gradientHandlePositions.len == 2
+approx(paint.gradientHandlePositions[1].x, 0.8)
+paint.gradientStops.add(colorStop(red, 0))
+paint.gradientStops.add(colorStop(green, 1))
+doAssert paint.gradientStops.len == 2
+doAssert paint.gradientStops[1].color == green
+
+let pathShape = newPath()
+pathShape.moveTo(1, 1)
+pathShape.lineTo(2, 2)
+pathShape.bezierCurveTo(1, 2, 3, 4, 5, 6)
+pathShape.quadraticCurveTo(1, 2, 3, 4)
+pathShape.ellipticalArcTo(1, 2, 3, false, true, 4, 5)
+pathShape.arc(1, 2, 3, 0, 1, false)
+pathShape.arcTo(1, 2, 3, 4, 5)
+pathShape.rect(0, 0, 3, 4, true)
+pathShape.roundedRect(0, 0, 3, 4, 1, 1, 1, 1, true)
+pathShape.ellipse(1, 2, 3, 4)
+pathShape.circle(1, 2, 3)
+pathShape.polygon(1, 2, 3, 5)
+pathShape.closePath()
+doAssert pathShape.computeBounds(identity).w > 0
+
+let rectPath = newPath()
+rectPath.rect(0, 0, 10, 10, true)
+let solidDashes = newSeqFloat32()
+doAssert rectPath.fillOverlaps(vector2(5, 5), identity, NonZero)
+doAssert rectPath.strokeOverlaps(vector2(0, 5), identity, 2, ButtCap, MiterJoin, defaultMiterLimit, solidDashes)
+
+let typeface = readTypeface(fontPath)
+doAssert ($typeface.filePath).endsWith("Inter-Regular.ttf")
+typeface.filePath = fontPath
+doAssert typeface.hasGlyph(Rune(ord('A')))
+doAssert typeface.getAdvance(Rune(ord('A'))) > 0
+doAssert typeface.getGlyphPath(Rune(ord('A'))).computeBounds(identity).w > 0
+
+let font = typeface.newFont()
+font.size = 24
+font.lineHeight = autoLineHeight
+font.paint = solid
+font.textCase = UpperCase
+font.underline = true
+font.strikethrough = true
+font.noKerningAdjustments = true
+font.paints.add(solid)
+doAssert font.paints.len >= 1
+doAssert font.scale() > 0
+doAssert font.defaultLineHeight() > 0
+doAssert font.layoutBounds("abcd").x > 0
+doAssert font.typeset("abcd", vector2(100, 100), LeftAlign, TopAlign, true).layoutBounds().x > 0
+
+let span = newSpan("hi", font)
+span.text = "hello"
+let spans = newSeqSpan()
+spans.add(span)
+let arrangement = spans.typeset(vector2(100, 100), CenterAlign, BottomAlign, true)
+doAssert $spans[0].text == "hello"
+doAssert arrangement.layoutBounds().x > 0
+doAssert spans.layoutBounds().y > 0
+doAssert arrangement.computeBounds(mat).x > 0
+
+let canvas = newImage(64, 64)
+canvas.fill(parseColor("#ffffff"))
+canvas.fillText(font, "abc", mat, vector2(60, 60), LeftAlign, TopAlign)
+canvas.fillText(arrangement, mat)
+canvas.strokeText(font, "abc", mat, 2, vector2(60, 60), LeftAlign, TopAlign, ButtCap, MiterJoin, defaultMiterLimit, dashes)
+canvas.strokeText(arrangement, mat, 2, ButtCap, MiterJoin, defaultMiterLimit, dashes)
+canvas.fillPath(rectPath, solid, mat, NonZero)
+canvas.strokePath(rectPath, solid, mat, 2, ButtCap, MiterJoin, defaultMiterLimit, dashes)
+
+let ctx = newContext(80, 80)
+ctx.globalAlpha = 0.75
+ctx.lineWidth = 2
+ctx.miterLimit = 5
+ctx.lineCap = RoundCap
+ctx.lineJoin = BevelJoin
+ctx.font = fontPath
+ctx.fontSize = 24
+ctx.textAlign = RightAlign
+doAssert ctx.textAlign == RightAlign
+doAssert ctx.measureText("abcd").width > 0
+ctx.setTransform(mat)
+doAssert ctx.getTransform().values[6] == 3
+ctx.transform(scale(2, 2))
+ctx.resetTransform()
+ctx.setLineDash(solidDashes)
+ctx.beginPath()
+ctx.rect(0, 0, 10, 10)
+doAssert ctx.isPointInPath(5, 5, NonZero)
+doAssert ctx.isPointInPath(rectPath, 5, 5, NonZero)
+doAssert ctx.isPointInStroke(0, 5)
+doAssert ctx.isPointInStroke(rectPath, 0, 5)
+ctx.setLineDash(dashes)
+doAssert ctx.getLineDash().len == 2
+ctx.moveTo(1, 1)
+ctx.lineTo(2, 2)
+ctx.bezierCurveTo(1, 2, 3, 4, 5, 6)
+ctx.quadraticCurveTo(1, 2, 3, 4)
+ctx.arc(1, 2, 3, 0, 1, false)
+ctx.arcTo(1, 2, 3, 4, 5)
+ctx.roundedRect(0, 0, 3, 4, 1, 1, 1, 1)
+ctx.ellipse(1, 2, 3, 4)
+ctx.circle(1, 2, 3)
+ctx.polygon(1, 2, 3, 5)
+ctx.closePath()
+ctx.fill(NonZero)
+ctx.fill(rectPath, EvenOdd)
+ctx.clip(NonZero)
+ctx.clip(rectPath, EvenOdd)
+ctx.stroke()
+ctx.stroke(rectPath)
+ctx.drawImage(canvas, 1, 2)
+ctx.drawImage2(canvas, 1, 2, 3, 4)
+ctx.drawImage3(canvas, 1, 2, 3, 4, 5, 6, 7, 8)
+ctx.clearRect(1, 2, 3, 4)
+ctx.fillRect(1, 2, 3, 4)
+ctx.strokeRect(1, 2, 3, 4)
+ctx.strokeSegment(1, 2, 3, 4)
+ctx.fillText("abc", 1, 2)
+ctx.strokeText("abc", 1, 2)
+ctx.translate(3, 4)
+ctx.scale(2, 3)
+ctx.rotate(0.5)
+ctx.save()
+ctx.saveLayer()
+ctx.restore()
+
+let decoded = decodeBase64($canvas.encodeBase64())
+doAssert decoded.width == canvas.width
+doAssert decoded.height == canvas.height
+doAssert decodeImage(ppm).width == 2
+doAssert decodeImageDimensions(ppm).height == 1
+doAssert readImage(imagePath).width == 40
+doAssert readImageDimensions(imagePath).height == 40
+approx(readFont(fontPath).size, 12)
+doAssert parsePath("M0 0 L10 0 L10 10 Z").computeBounds(identity).w == 10
+try:
+  discard parseColor("bad")
+  doAssert false
+except ValueError as e:
+  doAssert "bad" in e.msg
+
+echo "All Pixie Nim tests passed!"

--- a/tests/test_pixie_nim.nim
+++ b/tests/test_pixie_nim.nim
@@ -110,9 +110,9 @@ doAssert rectPath.strokeOverlaps(vector2(0, 5), identity, 2, ButtCap, MiterJoin,
 let typeface = readTypeface(fontPath)
 doAssert ($typeface.filePath).endsWith("Inter-Regular.ttf")
 typeface.filePath = fontPath
-doAssert typeface.hasGlyph(int32(ord('A')))
-doAssert typeface.getAdvance(int32(ord('A'))) > 0
-doAssert typeface.getGlyphPath(int32(ord('A'))).computeBounds(identity).w > 0
+doAssert typeface.hasGlyph(Rune(ord('A')))
+doAssert typeface.getAdvance(Rune(ord('A'))) > 0
+doAssert typeface.getGlyphPath(Rune(ord('A'))).computeBounds(identity).w > 0
 
 let font = typeface.newFont()
 font.size = 24

--- a/tests/test_pixie_nim.nim
+++ b/tests/test_pixie_nim.nim
@@ -110,9 +110,9 @@ doAssert rectPath.strokeOverlaps(vector2(0, 5), identity, 2, ButtCap, MiterJoin,
 let typeface = readTypeface(fontPath)
 doAssert ($typeface.filePath).endsWith("Inter-Regular.ttf")
 typeface.filePath = fontPath
-doAssert typeface.hasGlyph(Rune(ord('A')))
-doAssert typeface.getAdvance(Rune(ord('A'))) > 0
-doAssert typeface.getGlyphPath(Rune(ord('A'))).computeBounds(identity).w > 0
+doAssert typeface.hasGlyph(int32(ord('A')))
+doAssert typeface.getAdvance(int32(ord('A'))) > 0
+doAssert typeface.getGlyphPath(int32(ord('A'))).computeBounds(identity).w > 0
 
 let font = typeface.newFont()
 font.size = 24

--- a/tests/test_pixie_node.js
+++ b/tests/test_pixie_node.js
@@ -1,0 +1,242 @@
+const assert = require('assert');
+const Module = require('module');
+const path = require('path');
+
+process.env.NODE_PATH = [path.join(__dirname, 'node_modules'), process.env.NODE_PATH]
+  .filter(Boolean)
+  .join(path.delimiter);
+Module._initPaths();
+
+const pixieRoot = process.env.PIXIE_ROOT || path.join(__dirname, '..', '..', 'pixie');
+const bindingsDir = process.env.PIXIE_BINDINGS_DIR || path.join(pixieRoot, 'bindings', 'generated');
+const pixie = require(path.join(bindingsDir, 'pixie.js'));
+
+function asset(...parts) {
+  return path.join(pixieRoot, ...parts);
+}
+
+function approx(value, expected, eps = 0.0001) {
+  assert(Math.abs(value - expected) <= eps, `expected ${expected}, got ${value}`);
+}
+
+function assertColor(actual, expected) {
+  approx(actual.r, expected.r);
+  approx(actual.g, expected.g);
+  approx(actual.b, expected.b);
+  approx(actual.a, expected.a);
+}
+
+const fontPath = asset('tests', 'fonts', 'Inter-Regular.ttf');
+const imagePath = asset('tests', 'images', 'turtle.png');
+const ppm = 'P3\n2 1\n255\n255 0 0 0 255 0\n';
+
+assert.strictEqual(pixie.DEFAULT_MITER_LIMIT, 4);
+assert.strictEqual(pixie.AUTO_LINE_HEIGHT, -1);
+assert.strictEqual(pixie.PNG_FORMAT, 0);
+assert.strictEqual(pixie.LINEAR_GRADIENT_PAINT, 3);
+
+const red = pixie.parseColor('#ff0000');
+const green = pixie.parseColor('#00ff00');
+const mixed = pixie.mix(red, green, 0.25);
+approx(mixed.r, 0.75);
+approx(mixed.g, 0.25);
+
+const mat = pixie.translate(3, 4);
+const identity = pixie.translate(0, 0);
+assert.strictEqual(mat.values[6], 3);
+assert.strictEqual(pixie.inverse(mat).values[6], -3);
+assert.deepStrictEqual(pixie.snapToPixels(pixie.rect(1, 2, 3, 4)), pixie.rect(1, 2, 3, 4));
+assert(pixie.miterLimitToAngle(2) > 0);
+assert(pixie.angleToMiterLimit(1) > 0);
+
+const dashes = pixie.newSeqFloat32();
+dashes.add(1.5);
+dashes.add(2.5);
+dashes.set(1, 3.5);
+assert.strictEqual(dashes.length(), 2);
+approx(dashes.get(1), 3.5);
+
+const image = pixie.newImage(4, 3);
+assert.strictEqual(image.width, 4);
+assert.strictEqual(image.height, 3);
+assert(image.encodeBase64().length > 20);
+image.fill(red);
+assert(image.isOneColor());
+assert(image.isOpaque());
+assertColor(image.getColor(1, 1), red);
+image.setColor(0, 0, green);
+assert(!image.isOneColor());
+assert.strictEqual(image.copy().width, image.width);
+
+const solid = pixie.newPaint(pixie.SOLID_PAINT);
+solid.color = red;
+image.paintFill(solid);
+image.applyOpacity(0.5);
+approx(image.getColor(0, 0).a, 0.5, 0.01);
+image.invert();
+image.blur(1, red);
+
+const resized = image.resize(6, 5);
+assert.strictEqual(resized.width, 6);
+assert.strictEqual(resized.height, 5);
+resized.rotate90();
+assert.strictEqual(resized.width, 5);
+assert.strictEqual(resized.height, 6);
+assert.strictEqual(resized.subImage(0, 0, 2, 2).width, 2);
+assert.strictEqual(resized.rectSubImage(pixie.rect(0, 0, 1, 1)).height, 1);
+assert.strictEqual(resized.shadow(pixie.vector2(1, 2), 3, 4, red).width, resized.width);
+assert.strictEqual(resized.superImage(-1, -1, resized.width + 2, resized.height + 2).width, resized.width + 2);
+assert(resized.opaqueBounds().w > 0);
+
+const paint = pixie.newPaint(pixie.SOLID_PAINT);
+paint.kind = pixie.LINEAR_GRADIENT_PAINT;
+paint.blendMode = pixie.MULTIPLY_BLEND;
+paint.opacity = 0.5;
+paint.color = green;
+paint.imageMat = pixie.scale(2, 3);
+assert.strictEqual(paint.kind, pixie.LINEAR_GRADIENT_PAINT);
+approx(paint.opacity, 0.5);
+paint.gradientHandlePositions.add(pixie.vector2(0.25, 0));
+paint.gradientHandlePositions.add(pixie.vector2(0.75, 1));
+paint.gradientHandlePositions.set(1, pixie.vector2(0.8, 1));
+assert.strictEqual(paint.gradientHandlePositions.length(), 2);
+approx(paint.gradientHandlePositions.get(1).x, 0.8);
+paint.gradientStops.add(pixie.colorStop(red, 0));
+paint.gradientStops.add(pixie.colorStop(green, 1));
+assert.strictEqual(paint.gradientStops.length(), 2);
+assertColor(paint.gradientStops.get(1).color, green);
+
+const pathShape = pixie.newPath();
+pathShape.moveTo(1, 1);
+pathShape.lineTo(2, 2);
+pathShape.bezierCurveTo(1, 2, 3, 4, 5, 6);
+pathShape.quadraticCurveTo(1, 2, 3, 4);
+pathShape.ellipticalArcTo(1, 2, 3, false, true, 4, 5);
+pathShape.arc(1, 2, 3, 0, 1, false);
+pathShape.arcTo(1, 2, 3, 4, 5);
+pathShape.rect(0, 0, 3, 4, true);
+pathShape.roundedRect(0, 0, 3, 4, 1, 1, 1, 1, true);
+pathShape.ellipse(1, 2, 3, 4);
+pathShape.circle(1, 2, 3);
+pathShape.polygon(1, 2, 3, 5);
+pathShape.closePath();
+assert(pathShape.computeBounds(identity).w > 0);
+
+const rectPath = pixie.newPath();
+rectPath.rect(0, 0, 10, 10, true);
+const solidDashes = pixie.newSeqFloat32();
+assert(rectPath.fillOverlaps(pixie.vector2(5, 5), identity, pixie.NON_ZERO));
+assert(rectPath.strokeOverlaps(pixie.vector2(0, 5), identity, 2, pixie.BUTT_CAP, pixie.MITER_JOIN, pixie.DEFAULT_MITER_LIMIT, solidDashes));
+
+const typeface = pixie.readTypeface(fontPath);
+assert(typeface.filePath.endsWith('Inter-Regular.ttf'));
+typeface.filePath = fontPath;
+assert(typeface.hasGlyph('A'.codePointAt(0)));
+assert(typeface.getAdvance('A'.codePointAt(0)) > 0);
+assert(typeface.getGlyphPath('A'.codePointAt(0)).computeBounds(identity).w > 0);
+
+const font = typeface.newFont();
+font.size = 24;
+font.lineHeight = pixie.AUTO_LINE_HEIGHT;
+font.paint = solid;
+font.textCase = pixie.UPPER_CASE;
+font.underline = true;
+font.strikethrough = true;
+font.noKerningAdjustments = true;
+font.paints.add(solid);
+assert(font.paints.length() >= 1);
+assert(font.scale() > 0);
+assert(font.defaultLineHeight() > 0);
+assert(font.layoutBounds('abcd').x > 0);
+assert(font.typeset('abcd', pixie.vector2(100, 100), pixie.LEFT_ALIGN, pixie.TOP_ALIGN, true).layoutBounds().x > 0);
+
+const span = pixie.newSpan('hi', font);
+span.text = 'hello';
+const spans = pixie.newSeqSpan();
+spans.add(span);
+const arrangement = spans.typeset(pixie.vector2(100, 100), pixie.CENTER_ALIGN, pixie.BOTTOM_ALIGN, true);
+assert.strictEqual(spans.get(0).text, 'hello');
+assert(arrangement.layoutBounds().x > 0);
+assert(spans.layoutBounds().y > 0);
+assert(arrangement.computeBounds(mat).x > 0);
+
+const canvas = pixie.newImage(64, 64);
+canvas.fill(pixie.parseColor('#ffffff'));
+canvas.fillText(font, 'abc', mat, pixie.vector2(60, 60), pixie.LEFT_ALIGN, pixie.TOP_ALIGN);
+canvas.arrangementFillText(arrangement, mat);
+canvas.strokeText(font, 'abc', mat, 2, pixie.vector2(60, 60), pixie.LEFT_ALIGN, pixie.TOP_ALIGN, pixie.BUTT_CAP, pixie.MITER_JOIN, pixie.DEFAULT_MITER_LIMIT, dashes);
+canvas.arrangementStrokeText(arrangement, mat, 2, pixie.BUTT_CAP, pixie.MITER_JOIN, pixie.DEFAULT_MITER_LIMIT, dashes);
+canvas.fillPath(rectPath, solid, mat, pixie.NON_ZERO);
+canvas.strokePath(rectPath, solid, mat, 2, pixie.BUTT_CAP, pixie.MITER_JOIN, pixie.DEFAULT_MITER_LIMIT, dashes);
+
+const ctx = pixie.newContext(80, 80);
+ctx.globalAlpha = 0.75;
+ctx.lineWidth = 2;
+ctx.miterLimit = 5;
+ctx.lineCap = pixie.ROUND_CAP;
+ctx.lineJoin = pixie.BEVEL_JOIN;
+ctx.font = fontPath;
+ctx.fontSize = 24;
+ctx.textAlign = pixie.RIGHT_ALIGN;
+assert.strictEqual(ctx.textAlign, pixie.RIGHT_ALIGN);
+assert(ctx.measureText('abcd').width > 0);
+ctx.setTransform(mat);
+assert.strictEqual(ctx.getTransform().values[6], 3);
+ctx.transform(pixie.scale(2, 2));
+ctx.resetTransform();
+ctx.setLineDash(solidDashes);
+ctx.beginPath();
+ctx.rect(0, 0, 10, 10);
+assert(ctx.isPointInPath(5, 5, pixie.NON_ZERO));
+assert(ctx.pathIsPointInPath(rectPath, 5, 5, pixie.NON_ZERO));
+assert(ctx.isPointInStroke(0, 5));
+assert(ctx.pathIsPointInStroke(rectPath, 0, 5));
+ctx.setLineDash(dashes);
+assert.strictEqual(ctx.getLineDash().length(), 2);
+ctx.moveTo(1, 1);
+ctx.lineTo(2, 2);
+ctx.bezierCurveTo(1, 2, 3, 4, 5, 6);
+ctx.quadraticCurveTo(1, 2, 3, 4);
+ctx.arc(1, 2, 3, 0, 1, false);
+ctx.arcTo(1, 2, 3, 4, 5);
+ctx.roundedRect(0, 0, 3, 4, 1, 1, 1, 1);
+ctx.ellipse(1, 2, 3, 4);
+ctx.circle(1, 2, 3);
+ctx.polygon(1, 2, 3, 5);
+ctx.closePath();
+ctx.fill(pixie.NON_ZERO);
+ctx.pathFill(rectPath, pixie.EVEN_ODD);
+ctx.clip(pixie.NON_ZERO);
+ctx.pathClip(rectPath, pixie.EVEN_ODD);
+ctx.stroke();
+ctx.pathStroke(rectPath);
+ctx.drawImage(canvas, 1, 2);
+ctx.drawImage2(canvas, 1, 2, 3, 4);
+ctx.drawImage3(canvas, 1, 2, 3, 4, 5, 6, 7, 8);
+ctx.clearRect(1, 2, 3, 4);
+ctx.fillRect(1, 2, 3, 4);
+ctx.strokeRect(1, 2, 3, 4);
+ctx.strokeSegment(1, 2, 3, 4);
+ctx.fillText('abc', 1, 2);
+ctx.strokeText('abc', 1, 2);
+ctx.translate(3, 4);
+ctx.scale(2, 3);
+ctx.rotate(0.5);
+ctx.save();
+ctx.saveLayer();
+ctx.restore();
+
+const decoded = pixie.decodeBase64(canvas.encodeBase64());
+assert.strictEqual(decoded.width, canvas.width);
+assert.strictEqual(decoded.height, canvas.height);
+assert.strictEqual(pixie.decodeImage(ppm).width, 2);
+assert.strictEqual(pixie.decodeImageDimensions(ppm).height, 1);
+assert.strictEqual(pixie.readImage(imagePath).width, 40);
+assert.strictEqual(pixie.readImageDimensions(imagePath).height, 40);
+assert.strictEqual(pixie.readFont(fontPath).size, 12);
+assert.strictEqual(pixie.parsePath('M0 0 L10 0 L10 10 Z').computeBounds(identity).w, 10);
+pixie.parseColor('bad');
+assert(pixie.checkError());
+assert(pixie.takeError().includes('bad'));
+
+console.log('All Pixie Node tests passed!');

--- a/tests/test_pixie_node.js
+++ b/tests/test_pixie_node.js
@@ -7,8 +7,8 @@ process.env.NODE_PATH = [path.join(__dirname, 'node_modules'), process.env.NODE_
   .join(path.delimiter);
 Module._initPaths();
 
-const pixieRoot = process.env.PIXIE_ROOT || path.join(__dirname, '..', '..', 'pixie');
-const bindingsDir = process.env.PIXIE_BINDINGS_DIR || path.join(pixieRoot, 'bindings', 'generated');
+const pixieRoot = path.resolve(process.env.PIXIE_ROOT || path.join(__dirname, '..', '..', 'pixie'));
+const bindingsDir = path.resolve(process.env.PIXIE_BINDINGS_DIR || path.join(pixieRoot, 'bindings', 'generated'));
 const pixie = require(path.join(bindingsDir, 'pixie.js'));
 
 function asset(...parts) {
@@ -44,7 +44,6 @@ approx(mixed.g, 0.25);
 const mat = pixie.translate(3, 4);
 const identity = pixie.translate(0, 0);
 assert.strictEqual(mat.values[6], 3);
-assert.strictEqual(pixie.inverse(mat).values[6], -3);
 assert.deepStrictEqual(pixie.snapToPixels(pixie.rect(1, 2, 3, 4)), pixie.rect(1, 2, 3, 4));
 assert(pixie.miterLimitToAngle(2) > 0);
 assert(pixie.angleToMiterLimit(1) > 0);

--- a/tests/test_pixie_node.js
+++ b/tests/test_pixie_node.js
@@ -131,9 +131,11 @@ assert(rectPath.strokeOverlaps(pixie.vector2(0, 5), identity, 2, pixie.BUTT_CAP,
 const typeface = pixie.readTypeface(fontPath);
 assert(typeface.filePath.endsWith('Inter-Regular.ttf'));
 typeface.filePath = fontPath;
-assert(typeface.hasGlyph('A'.codePointAt(0)));
-assert(typeface.getAdvance('A'.codePointAt(0)) > 0);
-assert(typeface.getGlyphPath('A'.codePointAt(0)).computeBounds(identity).w > 0);
+assert(typeface.hasGlyph('A'));
+assert(typeface.getAdvance('A') > 0);
+assert(typeface.getGlyphPath('A').computeBounds(identity).w > 0);
+assert.throws(() => typeface.hasGlyph('AB'), assert.AssertionError);
+assert.throws(() => typeface.hasGlyph('\uD800'), assert.AssertionError);
 
 const font = typeface.newFont();
 font.size = 24;

--- a/tests/test_pixie_node.js
+++ b/tests/test_pixie_node.js
@@ -44,6 +44,7 @@ approx(mixed.g, 0.25);
 const mat = pixie.translate(3, 4);
 const identity = pixie.translate(0, 0);
 assert.strictEqual(mat.values[6], 3);
+assert.strictEqual(pixie.inverse(mat).values[6], -3);
 assert.deepStrictEqual(pixie.snapToPixels(pixie.rect(1, 2, 3, 4)), pixie.rect(1, 2, 3, 4));
 assert(pixie.miterLimitToAngle(2) > 0);
 assert(pixie.angleToMiterLimit(1) > 0);

--- a/tests/test_pixie_python.py
+++ b/tests/test_pixie_python.py
@@ -1,0 +1,32 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+from pixie_python_checks import run
+
+
+def bindings_dir():
+    return Path(os.environ.get("PIXIE_BINDINGS_DIR", Path(__file__).resolve().parents[2] / "pixie" / "bindings" / "generated"))
+
+
+def add_dll_dirs():
+    if os.name == "nt":
+        for entry in os.environ.get("PATH", "").split(os.pathsep):
+            if entry and Path(entry).is_dir():
+                os.add_dll_directory(entry)
+
+
+def load_ctypes_pixie():
+    module_path = bindings_dir() / "pixie.py"
+    spec = importlib.util.spec_from_file_location("pixie", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["pixie"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    add_dll_dirs()
+    run(load_ctypes_pixie())
+    print("All Pixie Python tests passed!")

--- a/tests/test_pixie_python_native.py
+++ b/tests/test_pixie_python_native.py
@@ -1,0 +1,23 @@
+import os
+import sys
+from pathlib import Path
+
+from pixie_python_checks import run
+
+
+def bindings_dir():
+    return Path(os.environ.get("PIXIE_BINDINGS_DIR", Path(__file__).resolve().parents[2] / "pixie" / "bindings" / "generated"))
+
+
+if os.name == "nt":
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if entry and Path(entry).is_dir():
+            os.add_dll_directory(entry)
+
+sys.path.insert(0, str(bindings_dir()))
+import pixie  # noqa: E402
+
+
+if __name__ == "__main__":
+    run(pixie)
+    print("All Pixie native Python tests passed!")

--- a/tests/test_pixie_zig.zig
+++ b/tests/test_pixie_zig.zig
@@ -32,6 +32,7 @@ pub fn main() !void {
     const mat = pixie.translate(3, 4);
     const identity = pixie.translate(0, 0);
     try expect(mat.values[6] == 3);
+    try expect(pixie.inverse(mat).values[6] == -3);
     try expect(pixie.snapToPixels(pixie.Rect.init(1, 2, 3, 4)).eql(pixie.Rect.init(1, 2, 3, 4)));
     try expect(pixie.miterLimitToAngle(2) > 0);
     try expect(pixie.angleToMiterLimit(1) > 0);

--- a/tests/test_pixie_zig.zig
+++ b/tests/test_pixie_zig.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const pixie = @import("../../pixie/bindings/generated/pixie.zig");
+const pixie = @import("generated/pixie.zig");
 
 fn expect(ok: bool) !void {
     if (!ok) return error.TestFailed;
@@ -32,7 +32,6 @@ pub fn main() !void {
     const mat = pixie.translate(3, 4);
     const identity = pixie.translate(0, 0);
     try expect(mat.values[6] == 3);
-    try expect(pixie.inverse(mat).values[6] == -3);
     try expect(pixie.snapToPixels(pixie.Rect.init(1, 2, 3, 4)).eql(pixie.Rect.init(1, 2, 3, 4)));
     try expect(pixie.miterLimitToAngle(2) > 0);
     try expect(pixie.angleToMiterLimit(1) > 0);

--- a/tests/test_pixie_zig.zig
+++ b/tests/test_pixie_zig.zig
@@ -1,0 +1,271 @@
+const std = @import("std");
+const pixie = @import("../../pixie/bindings/generated/pixie.zig");
+
+fn expect(ok: bool) !void {
+    if (!ok) return error.TestFailed;
+}
+
+fn approx(value: f32, expected: f32) !void {
+    try expect(@abs(value - expected) < 0.0001);
+}
+
+fn approxEps(value: f32, expected: f32, eps: f32) !void {
+    try expect(@abs(value - expected) <= eps);
+}
+
+pub fn main() !void {
+    const font_path = "../../pixie/tests/fonts/Inter-Regular.ttf";
+    const image_path = "../../pixie/tests/images/turtle.png";
+    const ppm = "P3\n2 1\n255\n255 0 0 0 255 0\n";
+
+    try expect(pixie.default_miter_limit == 4.0);
+    try expect(pixie.auto_line_height == -1.0);
+    try expect(@intFromEnum(pixie.FileFormat.png_format) == 0);
+    try expect(@intFromEnum(pixie.PaintKind.linear_gradient_paint) == 3);
+
+    const red = pixie.parseColor("#ff0000");
+    const green = pixie.parseColor("#00ff00");
+    const mixed = pixie.mix(red, green, 0.25);
+    try approx(mixed.r, 0.75);
+    try approx(mixed.g, 0.25);
+
+    const mat = pixie.translate(3, 4);
+    const identity = pixie.translate(0, 0);
+    try expect(mat.values[6] == 3);
+    try expect(pixie.inverse(mat).values[6] == -3);
+    try expect(pixie.snapToPixels(pixie.Rect.init(1, 2, 3, 4)).eql(pixie.Rect.init(1, 2, 3, 4)));
+    try expect(pixie.miterLimitToAngle(2) > 0);
+    try expect(pixie.angleToMiterLimit(1) > 0);
+
+    const dashes = pixie.SeqFloat32.init();
+    defer dashes.deinit();
+    dashes.append(1.5);
+    dashes.append(2.5);
+    dashes.set(1, 3.5);
+    try expect(dashes.len() == 2);
+    try approx(dashes.get(1), 3.5);
+
+    const image = pixie.Image.init(4, 3);
+    defer image.deinit();
+    try expect(image.getWidth() == 4);
+    try expect(image.getHeight() == 3);
+    try expect(image.encodeBase64().len > 20);
+    image.fill(red);
+    try expect(image.isOneColor());
+    try expect(image.isOpaque());
+    try expect(image.getColor(1, 1).eql(red));
+    image.setColor(0, 0, green);
+    try expect(!image.isOneColor());
+    const image_copy = image.copy();
+    defer image_copy.deinit();
+    try expect(image_copy.getWidth() == image.getWidth());
+
+    const solid = pixie.Paint.init(.solid_paint);
+    defer solid.deinit();
+    solid.setColor(red);
+    image.fillPaint(solid);
+    image.applyOpacity(0.5);
+    try approxEps(image.getColor(0, 0).a, 0.5, 0.01);
+    image.invert();
+    image.blur(1, red);
+
+    const resized = image.resize(6, 5);
+    defer resized.deinit();
+    try expect(resized.getWidth() == 6);
+    try expect(resized.getHeight() == 5);
+    resized.rotate90();
+    try expect(resized.getWidth() == 5);
+    try expect(resized.getHeight() == 6);
+    const sub = resized.subImage(0, 0, 2, 2);
+    defer sub.deinit();
+    try expect(sub.getWidth() == 2);
+    const rect_sub = resized.subImageRect(pixie.Rect.init(0, 0, 1, 1));
+    defer rect_sub.deinit();
+    try expect(rect_sub.getHeight() == 1);
+    const shadow = resized.shadow(pixie.Vector2.init(1, 2), 3, 4, red);
+    defer shadow.deinit();
+    try expect(shadow.getWidth() == resized.getWidth());
+    const super_image = resized.superImage(-1, -1, resized.getWidth() + 2, resized.getHeight() + 2);
+    defer super_image.deinit();
+    try expect(super_image.getWidth() == resized.getWidth() + 2);
+    try expect(resized.opaqueBounds().w > 0);
+
+    const paint = pixie.Paint.init(.solid_paint);
+    defer paint.deinit();
+    paint.setKind(.linear_gradient_paint);
+    paint.setBlendMode(.multiply_blend);
+    paint.setOpacity(0.5);
+    paint.setColor(green);
+    paint.setImageMat(pixie.scale(2, 3));
+    try expect(paint.getKind() == .linear_gradient_paint);
+    try approx(paint.getOpacity(), 0.5);
+    paint.appendGradientHandlePositions(pixie.Vector2.init(0.25, 0));
+    paint.appendGradientHandlePositions(pixie.Vector2.init(0.75, 1));
+    paint.setGradientHandlePositions(1, pixie.Vector2.init(0.8, 1));
+    try expect(paint.lenGradientHandlePositions() == 2);
+    try approx(paint.getGradientHandlePositions(1).x, 0.8);
+    paint.appendGradientStops(pixie.ColorStop.init(red, 0));
+    paint.appendGradientStops(pixie.ColorStop.init(green, 1));
+    try expect(paint.lenGradientStops() == 2);
+    try expect(paint.getGradientStops(1).color.eql(green));
+
+    const path = pixie.Path.init();
+    defer path.deinit();
+    path.moveTo(1, 1);
+    path.lineTo(2, 2);
+    path.bezierCurveTo(1, 2, 3, 4, 5, 6);
+    path.quadraticCurveTo(1, 2, 3, 4);
+    path.ellipticalArcTo(1, 2, 3, false, true, 4, 5);
+    path.arc(1, 2, 3, 0, 1, false);
+    path.arcTo(1, 2, 3, 4, 5);
+    path.rect(0, 0, 3, 4, true);
+    path.roundedRect(0, 0, 3, 4, 1, 1, 1, 1, true);
+    path.ellipse(1, 2, 3, 4);
+    path.circle(1, 2, 3);
+    path.polygon(1, 2, 3, 5);
+    path.closePath();
+    try expect(path.computeBounds(identity).w > 0);
+
+    const rect_path = pixie.Path.init();
+    defer rect_path.deinit();
+    rect_path.rect(0, 0, 10, 10, true);
+    const solid_dashes = pixie.SeqFloat32.init();
+    defer solid_dashes.deinit();
+    try expect(rect_path.fillOverlaps(pixie.Vector2.init(5, 5), identity, .non_zero));
+    try expect(rect_path.strokeOverlaps(pixie.Vector2.init(0, 5), identity, 2, .butt_cap, .miter_join, pixie.default_miter_limit, solid_dashes));
+
+    const typeface = pixie.readTypeface(font_path);
+    defer typeface.deinit();
+    try expect(std.mem.endsWith(u8, typeface.getFilePath(), "Inter-Regular.ttf"));
+    typeface.setFilePath(font_path);
+    try expect(typeface.hasGlyph('A'));
+    try expect(typeface.getAdvance('A') > 0);
+    const glyph = typeface.getGlyphPath('A');
+    defer glyph.deinit();
+    try expect(glyph.computeBounds(identity).w > 0);
+
+    const font = typeface.newFont();
+    defer font.deinit();
+    font.setSize(24);
+    font.setLineHeight(pixie.auto_line_height);
+    font.setPaint(solid);
+    font.setTextCase(.upper_case);
+    font.setUnderline(true);
+    font.setStrikethrough(true);
+    font.setNoKerningAdjustments(true);
+    font.appendPaints(solid);
+    try expect(font.lenPaints() >= 1);
+    try expect(font.scale() > 0);
+    try expect(font.defaultLineHeight() > 0);
+    try expect(font.layoutBounds("abcd").x > 0);
+    const font_arrangement = font.typeset("abcd", pixie.Vector2.init(100, 100), .left_align, .top_align, true);
+    defer font_arrangement.deinit();
+    try expect(font_arrangement.layoutBounds().x > 0);
+
+    const span = pixie.Span.init("hi", font);
+    defer span.deinit();
+    span.setText("hello");
+    const spans = pixie.SeqSpan.init();
+    defer spans.deinit();
+    spans.append(span);
+    const arrangement = spans.typeset(pixie.Vector2.init(100, 100), .center_align, .bottom_align, true);
+    defer arrangement.deinit();
+    try expect(std.mem.eql(u8, spans.get(0).getText(), "hello"));
+    try expect(arrangement.layoutBounds().x > 0);
+    try expect(spans.layoutBounds().y > 0);
+    try expect(arrangement.computeBounds(mat).x > 0);
+
+    const canvas = pixie.Image.init(64, 64);
+    defer canvas.deinit();
+    canvas.fill(pixie.parseColor("#ffffff"));
+    canvas.fillText(font, "abc", mat, pixie.Vector2.init(60, 60), .left_align, .top_align);
+    canvas.fillTextArrangement(arrangement, mat);
+    canvas.strokeText(font, "abc", mat, 2, pixie.Vector2.init(60, 60), .left_align, .top_align, .butt_cap, .miter_join, pixie.default_miter_limit, dashes);
+    canvas.strokeTextArrangement(arrangement, mat, 2, .butt_cap, .miter_join, pixie.default_miter_limit, dashes);
+    canvas.fillPath(rect_path, solid, mat, .non_zero);
+    canvas.strokePath(rect_path, solid, mat, 2, .butt_cap, .miter_join, pixie.default_miter_limit, dashes);
+
+    const ctx = pixie.Context.init(80, 80);
+    defer ctx.deinit();
+    ctx.setGlobalAlpha(0.75);
+    ctx.setLineWidth(2);
+    ctx.setMiterLimit(5);
+    ctx.setLineCap(.round_cap);
+    ctx.setLineJoin(.bevel_join);
+    ctx.setFont(font_path);
+    ctx.setFontSize(24);
+    ctx.setTextAlign(.right_align);
+    try expect(ctx.getTextAlign() == .right_align);
+    try expect(ctx.measureText("abcd").width > 0);
+    ctx.setTransform(mat);
+    try expect(ctx.getTransform().values[6] == 3);
+    ctx.transform(pixie.scale(2, 2));
+    ctx.resetTransform();
+    ctx.setLineDash(solid_dashes);
+    ctx.beginPath();
+    ctx.rect(0, 0, 10, 10);
+    try expect(ctx.isPointInPath(5, 5, .non_zero));
+    try expect(ctx.isPointInPathPath(rect_path, 5, 5, .non_zero));
+    try expect(ctx.isPointInStroke(0, 5));
+    try expect(ctx.isPointInStrokePath(rect_path, 0, 5));
+    ctx.setLineDash(dashes);
+    const ctx_dashes = ctx.getLineDash();
+    defer ctx_dashes.deinit();
+    try expect(ctx_dashes.len() == 2);
+    ctx.moveTo(1, 1);
+    ctx.lineTo(2, 2);
+    ctx.bezierCurveTo(1, 2, 3, 4, 5, 6);
+    ctx.quadraticCurveTo(1, 2, 3, 4);
+    ctx.arc(1, 2, 3, 0, 1, false);
+    ctx.arcTo(1, 2, 3, 4, 5);
+    ctx.roundedRect(0, 0, 3, 4, 1, 1, 1, 1);
+    ctx.ellipse(1, 2, 3, 4);
+    ctx.circle(1, 2, 3);
+    ctx.polygon(1, 2, 3, 5);
+    ctx.closePath();
+    ctx.fill(.non_zero);
+    ctx.fillPath(rect_path, .even_odd);
+    ctx.clip(.non_zero);
+    ctx.clipPath(rect_path, .even_odd);
+    ctx.stroke();
+    ctx.strokePath(rect_path);
+    ctx.drawImage(canvas, 1, 2);
+    ctx.drawImage2(canvas, 1, 2, 3, 4);
+    ctx.drawImage3(canvas, 1, 2, 3, 4, 5, 6, 7, 8);
+    ctx.clearRect(1, 2, 3, 4);
+    ctx.fillRect(1, 2, 3, 4);
+    ctx.strokeRect(1, 2, 3, 4);
+    ctx.strokeSegment(1, 2, 3, 4);
+    ctx.fillText("abc", 1, 2);
+    ctx.strokeText("abc", 1, 2);
+    ctx.translate(3, 4);
+    ctx.scale(2, 3);
+    ctx.rotate(0.5);
+    ctx.save();
+    ctx.saveLayer();
+    ctx.restore();
+
+    const decoded = pixie.decodeBase64(canvas.encodeBase64());
+    defer decoded.deinit();
+    try expect(decoded.getWidth() == canvas.getWidth());
+    try expect(decoded.getHeight() == canvas.getHeight());
+    const decoded_image = pixie.decodeImage(ppm);
+    defer decoded_image.deinit();
+    try expect(decoded_image.getWidth() == 2);
+    try expect(pixie.decodeImageDimensions(ppm).height == 1);
+    const read_image = pixie.readImage(image_path);
+    defer read_image.deinit();
+    try expect(read_image.getWidth() == 40);
+    try expect(pixie.readImageDimensions(image_path).height == 40);
+    const read_font = pixie.readFont(font_path);
+    defer read_font.deinit();
+    try approx(read_font.getSize(), 12);
+    const parsed_path = pixie.parsePath("M0 0 L10 0 L10 10 Z");
+    defer parsed_path.deinit();
+    try expect(parsed_path.computeBounds(identity).w == 10);
+    _ = pixie.parseColor("bad");
+    try expect(pixie.checkError());
+    try expect(std.mem.indexOf(u8, pixie.takeError(), "bad") != null);
+
+    try std.io.getStdOut().writer().print("All Pixie Zig tests passed!\n", .{});
+}

--- a/tests/test_pixie_zig.zig
+++ b/tests/test_pixie_zig.zig
@@ -14,6 +14,8 @@ fn approxEps(value: f32, expected: f32, eps: f32) !void {
 }
 
 pub fn main() !void {
+    @setEvalBranchQuota(10000);
+
     const font_path = "../../pixie/tests/fonts/Inter-Regular.ttf";
     const image_path = "../../pixie/tests/images/turtle.png";
     const ppm = "P3\n2 1\n255\n255 0 0 0 255 0\n";


### PR DESCRIPTION
- Add real Pixie binding smoke coverage for C, C++, Nim, Node, Python ctypes, Python native, and Zig.
- Build those tests from `../pixie/bindings/bindings.nim` in CI instead of a synthetic fixture.
- Fix generator handling for Pixie-shaped APIs: `sink[T]`, `openArray`, ref-object returns, value-object conversions, and Node/Nim wrapper typing.
