### PR TITLE
C++ ergonomics

### DIFF
--- a/src/genny/languages/cpp.nim
+++ b/src/genny/languages/cpp.nim
@@ -39,24 +39,24 @@ proc exportTypeCpp(sym: NimNode, abi = false): string =
   else:
     result =
       case typ.repr:
-      of "string": "const char*"
+      of "string", "cstring": "const char*"
       of "bool": "bool"
-      of "byte": "char"
-      of "int8": "int8_t"
-      of "int16": "int16_t"
-      of "int32": "int32_t"
-      of "int64": "int64_t"
-      of "int": "int64_t"
-      of "uint8": "uint8_t"
-      of "uint16": "uint16_t"
-      of "uint32": "uint32_t"
-      of "uint64": "uint64_t"
-      of "uint": "uint64_t"
+      of "byte": "std::uint8_t"
+      of "int8": "std::int8_t"
+      of "int16": "std::int16_t"
+      of "int32": "std::int32_t"
+      of "int64": "std::int64_t"
+      of "int": "std::intptr_t"
+      of "uint8": "std::uint8_t"
+      of "uint16": "std::uint16_t"
+      of "uint32": "std::uint32_t"
+      of "uint64": "std::uint64_t"
+      of "uint": "std::uintptr_t"
       of "float32": "float"
       of "float64": "double"
       of "float": "double"
       of "Rune":
-        if abi: "int32_t" else: "char32_t"
+        if abi: "std::int32_t" else: "char32_t"
       of "Vec2": "Vector2"
       of "Mat3": "Matrix3"
       of "", "nil": "void"
@@ -90,7 +90,7 @@ proc exportTypeCppAbi(sym: NimNode, name: string): string =
 
 proc cppArgValue(argType: NimNode, argName: string): string =
   if argType.isRuneType:
-    &"static_cast<int32_t>({argName})"
+    &"static_cast<std::int32_t>({argName})"
   else:
     argName
 
@@ -119,13 +119,13 @@ proc dllProc*(procName: string, restype: string) =
   dllProc(procName, a, restype)
 
 proc exportConstCpp*(sym: NimNode) =
-  types.add &"#define {toCapSnakeCase(sym.repr)} {sym.getImpl()[2].repr}\n"
+  types.add &"static constexpr auto {toCapSnakeCase(sym.repr)} = {sym.getImpl()[2].repr};\n"
   types.add "\n"
 
 proc exportEnumCpp*(sym: NimNode) =
-  types.add &"typedef char {sym.repr};\n"
+  types.add &"using {sym.repr} = std::uint8_t;\n"
   for i, entry in sym.getImpl()[2][1 .. ^1]:
-    types.add &"#define {toCapSnakeCase(entry.repr)} {i}\n"
+    types.add &"static constexpr {sym.repr} {toCapSnakeCase(entry.repr)} = {i};\n"
   types.add "\n"
 
 proc exportProcCpp*(
@@ -265,7 +265,7 @@ proc exportObjectCpp*(sym: NimNode, constructor: NimNode) =
     members.add ");\n"
     members.add "};\n\n"
 
-  dllProc(&"$lib_{toSnakeCase(objName)}_eq", [&"{objName} a", &"{objName} b"], "char")
+  dllProc(&"$lib_{toSnakeCase(objName)}_eq", [&"{objName} a", &"{objName} b"], "bool")
 
 proc genRefObject(objName: string) =
 
@@ -277,12 +277,94 @@ proc genRefObject(objName: string) =
 
 proc genSeqProcs(objName, procPrefix, selfSuffix: string, entryType: NimNode) =
   let objArg = objName & " " & toSnakeCase(objName)
-  dllProc(&"{procPrefix}_len", [objArg], "int64_t")
-  dllProc(&"{procPrefix}_get", [objArg, "int64_t index"], exportTypeCppAbi(entryType))
-  dllProc(&"{procPrefix}_set", [objArg, "int64_t index", exportTypeCppAbi(entryType, "value")], "void")
-  dllProc(&"{procPrefix}_delete", [objArg, "int64_t index"], "void")
+  dllProc(&"{procPrefix}_len", [objArg], "std::intptr_t")
+  dllProc(&"{procPrefix}_get", [objArg, "std::intptr_t index"], exportTypeCppAbi(entryType))
+  dllProc(&"{procPrefix}_set", [objArg, "std::intptr_t index", exportTypeCppAbi(entryType, "value")], "void")
+  dllProc(&"{procPrefix}_delete", [objArg, "std::intptr_t index"], "void")
   dllProc(&"{procPrefix}_add", [objArg, exportTypeCppAbi(entryType, "value")], "void")
   dllProc(&"{procPrefix}_clear", [objArg], "void")
+
+proc genSeqClassMethods(seqName, procPrefix: string, entryType: NimNode) =
+  let
+    entryTypeCpp = exportTypeCpp(entryType)
+    entryValue = cppArgValue(entryType, "value")
+    getCall = &"{procPrefix}_get(*this, index)"
+
+  classes.add &"  std::intptr_t size();\n"
+  classes.add &"  {entryTypeCpp} get(std::intptr_t index);\n"
+  classes.add &"  {entryTypeCpp} operator[](std::intptr_t index);\n"
+  classes.add &"  void set(std::intptr_t index, {entryTypeCpp} value);\n"
+  classes.add &"  void removeAt(std::intptr_t index);\n"
+  classes.add &"  void add({entryTypeCpp} value);\n"
+  classes.add &"  void clear();\n\n"
+
+  members.add &"std::intptr_t {seqName}::size()" & "{\n"
+  members.add &"  return {procPrefix}_len(*this);\n"
+  members.add "}\n\n"
+
+  members.add &"{entryTypeCpp} {seqName}::get(std::intptr_t index)" & "{\n"
+  members.add &"  return {cppReturnValue(entryType, getCall)};\n"
+  members.add "}\n\n"
+
+  members.add &"{entryTypeCpp} {seqName}::operator[](std::intptr_t index)" & "{\n"
+  members.add &"  return get(index);\n"
+  members.add "}\n\n"
+
+  members.add &"void {seqName}::set(std::intptr_t index, {entryTypeCpp} value)" & "{\n"
+  members.add &"  {procPrefix}_set(*this, index, {entryValue});\n"
+  members.add "}\n\n"
+
+  members.add &"void {seqName}::removeAt(std::intptr_t index)" & "{\n"
+  members.add &"  {procPrefix}_delete(*this, index);\n"
+  members.add "}\n\n"
+
+  members.add &"void {seqName}::add({entryTypeCpp} value)" & "{\n"
+  members.add &"  {procPrefix}_add(*this, {entryValue});\n"
+  members.add "}\n\n"
+
+  members.add &"void {seqName}::clear()" & "{\n"
+  members.add &"  {procPrefix}_clear(*this);\n"
+  members.add "}\n\n"
+
+proc genSeqFieldMethods(objName, procPrefix, fieldName: string, entryType: NimNode) =
+  var fieldCap = fieldName
+  fieldCap[0] = toUpperAscii(fieldCap[0])
+
+  let
+    entryTypeCpp = exportTypeCpp(entryType)
+    entryValue = cppArgValue(entryType, "value")
+    getCall = &"{procPrefix}_get(*this, index)"
+
+  classes.add &"  std::intptr_t {fieldName}Size();\n"
+  classes.add &"  {entryTypeCpp} get{fieldCap}(std::intptr_t index);\n"
+  classes.add &"  void set{fieldCap}(std::intptr_t index, {entryTypeCpp} value);\n"
+  classes.add &"  void remove{fieldCap}(std::intptr_t index);\n"
+  classes.add &"  void add{fieldCap}({entryTypeCpp} value);\n"
+  classes.add &"  void clear{fieldCap}();\n\n"
+
+  members.add &"std::intptr_t {objName}::{fieldName}Size()" & "{\n"
+  members.add &"  return {procPrefix}_len(*this);\n"
+  members.add "}\n\n"
+
+  members.add &"{entryTypeCpp} {objName}::get{fieldCap}(std::intptr_t index)" & "{\n"
+  members.add &"  return {cppReturnValue(entryType, getCall)};\n"
+  members.add "}\n\n"
+
+  members.add &"void {objName}::set{fieldCap}(std::intptr_t index, {entryTypeCpp} value)" & "{\n"
+  members.add &"  {procPrefix}_set(*this, index, {entryValue});\n"
+  members.add "}\n\n"
+
+  members.add &"void {objName}::remove{fieldCap}(std::intptr_t index)" & "{\n"
+  members.add &"  {procPrefix}_delete(*this, index);\n"
+  members.add "}\n\n"
+
+  members.add &"void {objName}::add{fieldCap}({entryTypeCpp} value)" & "{\n"
+  members.add &"  {procPrefix}_add(*this, {entryValue});\n"
+  members.add "}\n\n"
+
+  members.add &"void {objName}::clear{fieldCap}()" & "{\n"
+  members.add &"  {procPrefix}_clear(*this);\n"
+  members.add "}\n\n"
 
 proc exportRefObjectCpp*(
   sym: NimNode,
@@ -298,7 +380,7 @@ proc exportRefObjectCpp*(
 
   classes.add &"struct {objName} " & "{\n\n"
   classes.add &"  private:\n\n"
-  classes.add &"  uint64_t reference;\n\n"
+  classes.add &"  std::uintptr_t reference;\n\n"
   classes.add &"  public:\n\n"
 
   if constructor != nil:
@@ -377,6 +459,12 @@ proc exportRefObjectCpp*(
         &".{toSnakeCase(objName)}",
         fieldType[1]
       )
+      genSeqFieldMethods(
+        objName,
+        &"$lib_{objNameSnaked}_{fieldNameSnaked}",
+        fieldName,
+        fieldType[1]
+      )
 
   # TODO: ref/unref
   # classes.add &"  ~{objName}();\n\n"
@@ -415,10 +503,22 @@ proc exportSeqCpp*(sym: NimNode) =
 
   classes.add &"struct {seqName} " & "{\n\n"
   classes.add &"  private:\n\n"
-  classes.add &"  uint64_t reference;\n\n"
+  classes.add &"  std::uintptr_t reference;\n\n"
   classes.add &"  public:\n\n"
 
+  classes.add &"  {seqName}();\n\n"
+
   classes.add &"  void free();\n\n"
+
+  members.add &"{seqName}::{seqName}()" & "{\n"
+  members.add &"  this->reference = {newSeqProc}().reference;\n"
+  members.add "}\n\n"
+
+  genSeqClassMethods(
+    seqName,
+    &"$lib_{seqNameSnaked}",
+    sym[1]
+  )
 
   members.add &"void {seqName}::free()" & "{\n"
   members.add &"  $lib_{toSnakeCase(seqName)}_unref(*this);\n"
@@ -429,7 +529,7 @@ const header = """
 #ifndef INCLUDE_$LIB_H
 #define INCLUDE_$LIB_H
 
-#include <stdint.h>
+#include <cstdint>
 
 """
 

--- a/tests/generated/test.hpp
+++ b/tests/generated/test.hpp
@@ -1,14 +1,14 @@
 #ifndef INCLUDE_TEST_H
 #define INCLUDE_TEST_H
 
-#include <stdint.h>
+#include <cstdint>
 
-#define SIMPLE_CONST 123
+static constexpr auto SIMPLE_CONST = 123;
 
-typedef char SimpleEnum;
-#define FIRST 0
-#define SECOND 1
-#define THIRD 2
+using SimpleEnum = std::uint8_t;
+static constexpr SimpleEnum FIRST = 0;
+static constexpr SimpleEnum SECOND = 1;
+static constexpr SimpleEnum THIRD = 2;
 
 struct SimpleObj;
 
@@ -23,8 +23,8 @@ struct SimpleObjWithProc;
 struct SeqString;
 
 struct SimpleObj {
-  int64_t simple_a;
-  char simple_b;
+  std::intptr_t simple_a;
+  std::uint8_t simple_b;
   bool simple_c;
 };
 
@@ -32,17 +32,17 @@ struct SimpleRefObj {
 
   private:
 
-  uint64_t reference;
+  std::uintptr_t reference;
 
   public:
 
   SimpleRefObj();
 
-  int64_t getSimpleRefA();
-  void setSimpleRefA(int64_t value);
+  std::intptr_t getSimpleRefA();
+  void setSimpleRefA(std::intptr_t value);
 
-  char getSimpleRefB();
-  void setSimpleRefB(char value);
+  std::uint8_t getSimpleRefB();
+  void setSimpleRefB(std::uint8_t value);
 
   void free();
 
@@ -57,11 +57,21 @@ struct SeqInt {
 
   private:
 
-  uint64_t reference;
+  std::uintptr_t reference;
 
   public:
 
+  SeqInt();
+
   void free();
+
+  std::intptr_t size();
+  std::intptr_t get(std::intptr_t index);
+  std::intptr_t operator[](std::intptr_t index);
+  void set(std::intptr_t index, std::intptr_t value);
+  void removeAt(std::intptr_t index);
+  void add(std::intptr_t value);
+  void clear();
 
 };
 
@@ -69,19 +79,26 @@ struct RefObjWithSeq {
 
   private:
 
-  uint64_t reference;
+  std::uintptr_t reference;
 
   public:
 
   RefObjWithSeq();
+
+  std::intptr_t dataSize();
+  std::uint8_t getData(std::intptr_t index);
+  void setData(std::intptr_t index, std::uint8_t value);
+  void removeData(std::intptr_t index);
+  void addData(std::uint8_t value);
+  void clearData();
 
   void free();
 
 };
 
 struct SimpleObjWithProc {
-  int64_t simple_a;
-  char simple_b;
+  std::intptr_t simple_a;
+  std::uint8_t simple_b;
   bool simple_c;
   void extraProc();
 
@@ -91,33 +108,43 @@ struct SeqString {
 
   private:
 
-  uint64_t reference;
+  std::uintptr_t reference;
 
   public:
 
+  SeqString();
+
   void free();
+
+  std::intptr_t size();
+  const char* get(std::intptr_t index);
+  const char* operator[](std::intptr_t index);
+  void set(std::intptr_t index, const char* value);
+  void removeAt(std::intptr_t index);
+  void add(const char* value);
+  void clear();
 
 };
 
 extern "C" {
 
-int64_t test_simple_call(int64_t a);
+std::intptr_t test_simple_call(std::intptr_t a);
 
-SimpleObj test_simple_obj(int64_t simple_a, char simple_b, bool simple_c);
+SimpleObj test_simple_obj(std::intptr_t simple_a, std::uint8_t simple_b, bool simple_c);
 
-char test_simple_obj_eq(SimpleObj a, SimpleObj b);
+bool test_simple_obj_eq(SimpleObj a, SimpleObj b);
 
 void test_simple_ref_obj_unref(SimpleRefObj simple_ref_obj);
 
 SimpleRefObj test_new_simple_ref_obj();
 
-int64_t test_simple_ref_obj_get_simple_ref_a(SimpleRefObj simple_ref_obj);
+std::intptr_t test_simple_ref_obj_get_simple_ref_a(SimpleRefObj simple_ref_obj);
 
-void test_simple_ref_obj_set_simple_ref_a(SimpleRefObj simple_ref_obj, int64_t value);
+void test_simple_ref_obj_set_simple_ref_a(SimpleRefObj simple_ref_obj, std::intptr_t value);
 
-char test_simple_ref_obj_get_simple_ref_b(SimpleRefObj simple_ref_obj);
+std::uint8_t test_simple_ref_obj_get_simple_ref_b(SimpleRefObj simple_ref_obj);
 
-void test_simple_ref_obj_set_simple_ref_b(SimpleRefObj simple_ref_obj, char value);
+void test_simple_ref_obj_set_simple_ref_b(SimpleRefObj simple_ref_obj, std::uint8_t value);
 
 void test_simple_ref_obj_doit(SimpleRefObj s);
 
@@ -125,15 +152,15 @@ void test_seq_int_unref(SeqInt seq_int);
 
 SeqInt test_new_seq_int();
 
-int64_t test_seq_int_len(SeqInt seq_int);
+std::intptr_t test_seq_int_len(SeqInt seq_int);
 
-int64_t test_seq_int_get(SeqInt seq_int, int64_t index);
+std::intptr_t test_seq_int_get(SeqInt seq_int, std::intptr_t index);
 
-void test_seq_int_set(SeqInt seq_int, int64_t index, int64_t value);
+void test_seq_int_set(SeqInt seq_int, std::intptr_t index, std::intptr_t value);
 
-void test_seq_int_delete(SeqInt seq_int, int64_t index);
+void test_seq_int_delete(SeqInt seq_int, std::intptr_t index);
 
-void test_seq_int_add(SeqInt seq_int, int64_t value);
+void test_seq_int_add(SeqInt seq_int, std::intptr_t value);
 
 void test_seq_int_clear(SeqInt seq_int);
 
@@ -141,21 +168,21 @@ void test_ref_obj_with_seq_unref(RefObjWithSeq ref_obj_with_seq);
 
 RefObjWithSeq test_new_ref_obj_with_seq();
 
-int64_t test_ref_obj_with_seq_data_len(RefObjWithSeq ref_obj_with_seq);
+std::intptr_t test_ref_obj_with_seq_data_len(RefObjWithSeq ref_obj_with_seq);
 
-char test_ref_obj_with_seq_data_get(RefObjWithSeq ref_obj_with_seq, int64_t index);
+std::uint8_t test_ref_obj_with_seq_data_get(RefObjWithSeq ref_obj_with_seq, std::intptr_t index);
 
-void test_ref_obj_with_seq_data_set(RefObjWithSeq ref_obj_with_seq, int64_t index, char value);
+void test_ref_obj_with_seq_data_set(RefObjWithSeq ref_obj_with_seq, std::intptr_t index, std::uint8_t value);
 
-void test_ref_obj_with_seq_data_delete(RefObjWithSeq ref_obj_with_seq, int64_t index);
+void test_ref_obj_with_seq_data_delete(RefObjWithSeq ref_obj_with_seq, std::intptr_t index);
 
-void test_ref_obj_with_seq_data_add(RefObjWithSeq ref_obj_with_seq, char value);
+void test_ref_obj_with_seq_data_add(RefObjWithSeq ref_obj_with_seq, std::uint8_t value);
 
 void test_ref_obj_with_seq_data_clear(RefObjWithSeq ref_obj_with_seq);
 
-SimpleObjWithProc test_simple_obj_with_proc(int64_t simple_a, char simple_b, bool simple_c);
+SimpleObjWithProc test_simple_obj_with_proc(std::intptr_t simple_a, std::uint8_t simple_b, bool simple_c);
 
-char test_simple_obj_with_proc_eq(SimpleObjWithProc a, SimpleObjWithProc b);
+bool test_simple_obj_with_proc_eq(SimpleObjWithProc a, SimpleObjWithProc b);
 
 void test_simple_obj_with_proc_extra_proc(SimpleObjWithProc s);
 
@@ -163,13 +190,13 @@ void test_seq_string_unref(SeqString seq_string);
 
 SeqString test_new_seq_string();
 
-int64_t test_seq_string_len(SeqString seq_string);
+std::intptr_t test_seq_string_len(SeqString seq_string);
 
-const char* test_seq_string_get(SeqString seq_string, int64_t index);
+const char* test_seq_string_get(SeqString seq_string, std::intptr_t index);
 
-void test_seq_string_set(SeqString seq_string, int64_t index, const char* value);
+void test_seq_string_set(SeqString seq_string, std::intptr_t index, const char* value);
 
-void test_seq_string_delete(SeqString seq_string, int64_t index);
+void test_seq_string_delete(SeqString seq_string, std::intptr_t index);
 
 void test_seq_string_add(SeqString seq_string, const char* value);
 
@@ -179,11 +206,11 @@ SeqString test_get_datas();
 
 }
 
-int64_t simpleCall(int64_t a) {
+std::intptr_t simpleCall(std::intptr_t a) {
   return test_simple_call(a);
 };
 
-SimpleObj simpleObj(int64_t simpleA, char simpleB, bool simpleC) {
+SimpleObj simpleObj(std::intptr_t simpleA, std::uint8_t simpleB, bool simpleC) {
   return test_simple_obj(simpleA, simpleB, simpleC);
 };
 
@@ -191,19 +218,19 @@ SimpleRefObj::SimpleRefObj() {
   this->reference = test_new_simple_ref_obj().reference;
 }
 
-int64_t SimpleRefObj::getSimpleRefA(){
+std::intptr_t SimpleRefObj::getSimpleRefA(){
   return test_simple_ref_obj_get_simple_ref_a(*this);
 }
 
-void SimpleRefObj::setSimpleRefA(int64_t value){
+void SimpleRefObj::setSimpleRefA(std::intptr_t value){
   test_simple_ref_obj_set_simple_ref_a(*this, value);
 }
 
-char SimpleRefObj::getSimpleRefB(){
+std::uint8_t SimpleRefObj::getSimpleRefB(){
   return test_simple_ref_obj_get_simple_ref_b(*this);
 }
 
-void SimpleRefObj::setSimpleRefB(char value){
+void SimpleRefObj::setSimpleRefB(std::uint8_t value){
   test_simple_ref_obj_set_simple_ref_b(*this, value);
 }
 
@@ -215,6 +242,38 @@ void SimpleRefObj::doit() {
   test_simple_ref_obj_doit(*this);
 };
 
+SeqInt::SeqInt(){
+  this->reference = test_new_seq_int().reference;
+}
+
+std::intptr_t SeqInt::size(){
+  return test_seq_int_len(*this);
+}
+
+std::intptr_t SeqInt::get(std::intptr_t index){
+  return test_seq_int_get(*this, index);
+}
+
+std::intptr_t SeqInt::operator[](std::intptr_t index){
+  return get(index);
+}
+
+void SeqInt::set(std::intptr_t index, std::intptr_t value){
+  test_seq_int_set(*this, index, value);
+}
+
+void SeqInt::removeAt(std::intptr_t index){
+  test_seq_int_delete(*this, index);
+}
+
+void SeqInt::add(std::intptr_t value){
+  test_seq_int_add(*this, value);
+}
+
+void SeqInt::clear(){
+  test_seq_int_clear(*this);
+}
+
 void SeqInt::free(){
   test_seq_int_unref(*this);
 }
@@ -223,17 +282,73 @@ RefObjWithSeq::RefObjWithSeq() {
   this->reference = test_new_ref_obj_with_seq().reference;
 }
 
+std::intptr_t RefObjWithSeq::dataSize(){
+  return test_ref_obj_with_seq_data_len(*this);
+}
+
+std::uint8_t RefObjWithSeq::getData(std::intptr_t index){
+  return test_ref_obj_with_seq_data_get(*this, index);
+}
+
+void RefObjWithSeq::setData(std::intptr_t index, std::uint8_t value){
+  test_ref_obj_with_seq_data_set(*this, index, value);
+}
+
+void RefObjWithSeq::removeData(std::intptr_t index){
+  test_ref_obj_with_seq_data_delete(*this, index);
+}
+
+void RefObjWithSeq::addData(std::uint8_t value){
+  test_ref_obj_with_seq_data_add(*this, value);
+}
+
+void RefObjWithSeq::clearData(){
+  test_ref_obj_with_seq_data_clear(*this);
+}
+
 void RefObjWithSeq::free(){
   test_ref_obj_with_seq_unref(*this);
 }
 
-SimpleObjWithProc simpleObjWithProc(int64_t simpleA, char simpleB, bool simpleC) {
+SimpleObjWithProc simpleObjWithProc(std::intptr_t simpleA, std::uint8_t simpleB, bool simpleC) {
   return test_simple_obj_with_proc(simpleA, simpleB, simpleC);
 };
 
 void SimpleObjWithProc::extraProc() {
   test_simple_obj_with_proc_extra_proc(*this);
 };
+
+SeqString::SeqString(){
+  this->reference = test_new_seq_string().reference;
+}
+
+std::intptr_t SeqString::size(){
+  return test_seq_string_len(*this);
+}
+
+const char* SeqString::get(std::intptr_t index){
+  return test_seq_string_get(*this, index);
+}
+
+const char* SeqString::operator[](std::intptr_t index){
+  return get(index);
+}
+
+void SeqString::set(std::intptr_t index, const char* value){
+  test_seq_string_set(*this, index, value);
+}
+
+void SeqString::removeAt(std::intptr_t index){
+  test_seq_string_delete(*this, index);
+}
+
+void SeqString::add(const char* value){
+  test_seq_string_add(*this, value);
+}
+
+void SeqString::clear(){
+  test_seq_string_clear(*this);
+}
 
 void SeqString::free(){
   test_seq_string_unref(*this);

--- a/tests/test_cpp.cpp
+++ b/tests/test_cpp.cpp
@@ -28,8 +28,35 @@ int main() {
     refObj.doit();
     refObj.free();
 
+    std::cout << "Testing SeqInt" << std::endl;
+    SeqInt seqInt;
+    seqInt.add(1);
+    seqInt.add(2);
+    seqInt.set(1, 20);
+    assert(seqInt.size() == 2);
+    assert(seqInt.get(0) == 1);
+    assert(seqInt[1] == 20);
+    seqInt.removeAt(0);
+    assert(seqInt.size() == 1);
+    seqInt.clear();
+    assert(seqInt.size() == 0);
+    seqInt.free();
+
+    std::cout << "Testing RefObjWithSeq" << std::endl;
+    RefObjWithSeq refObjWithSeq;
+    refObjWithSeq.addData(7);
+    assert(refObjWithSeq.dataSize() == 1);
+    assert(refObjWithSeq.getData(0) == 7);
+    refObjWithSeq.setData(0, 8);
+    assert(refObjWithSeq.getData(0) == 8);
+    refObjWithSeq.removeData(0);
+    assert(refObjWithSeq.dataSize() == 0);
+    refObjWithSeq.free();
+
     std::cout << "Testing SeqString via getDatas" << std::endl;
     SeqString datas = getDatas();
+    assert(datas.size() == 3);
+    assert(datas[0][0] == 'a');
     datas.free();
 
     std::cout << "All C++ tests passed!" << std::endl;

--- a/tests/test_pixie_cpp.cpp
+++ b/tests/test_pixie_cpp.cpp
@@ -44,12 +44,12 @@ int main() {
     assert(miterLimitToAngle(2) > 0);
     assert(angleToMiterLimit(1) > 0);
 
-    SeqFloat32 dashes = pixie_new_seq_float32();
-    pixie_seq_float32_add(dashes, 1.5f);
-    pixie_seq_float32_add(dashes, 2.5f);
-    pixie_seq_float32_set(dashes, 1, 3.5f);
-    assert(pixie_seq_float32_len(dashes) == 2);
-    approx(pixie_seq_float32_get(dashes, 1), 3.5f);
+    SeqFloat32 dashes;
+    dashes.add(1.5f);
+    dashes.add(2.5f);
+    dashes.set(1, 3.5f);
+    assert(dashes.size() == 2);
+    approx(dashes[1], 3.5f);
 
     Image image(4, 3);
     assert(image.getWidth() == 4);
@@ -91,15 +91,15 @@ int main() {
     paint.setImageMat(scale(2, 3));
     assert(paint.getKind() == LINEAR_GRADIENT_PAINT);
     approx(paint.getOpacity(), 0.5f);
-    pixie_paint_gradient_handle_positions_add(paint, vector2(0.25f, 0));
-    pixie_paint_gradient_handle_positions_add(paint, vector2(0.75f, 1));
-    pixie_paint_gradient_handle_positions_set(paint, 1, vector2(0.8f, 1));
-    assert(pixie_paint_gradient_handle_positions_len(paint) == 2);
-    approx(pixie_paint_gradient_handle_positions_get(paint, 1).x, 0.8f);
-    pixie_paint_gradient_stops_add(paint, colorStop(red, 0));
-    pixie_paint_gradient_stops_add(paint, colorStop(green, 1));
-    assert(pixie_paint_gradient_stops_len(paint) == 2);
-    assertColor(pixie_paint_gradient_stops_get(paint, 1).color, green);
+    paint.addGradientHandlePositions(vector2(0.25f, 0));
+    paint.addGradientHandlePositions(vector2(0.75f, 1));
+    paint.setGradientHandlePositions(1, vector2(0.8f, 1));
+    assert(paint.gradientHandlePositionsSize() == 2);
+    approx(paint.getGradientHandlePositions(1).x, 0.8f);
+    paint.addGradientStops(colorStop(red, 0));
+    paint.addGradientStops(colorStop(green, 1));
+    assert(paint.gradientStopsSize() == 2);
+    assertColor(paint.getGradientStops(1).color, green);
 
     Path path;
     path.moveTo(1, 1);
@@ -119,7 +119,7 @@ int main() {
 
     Path rectPath;
     rectPath.rect(0, 0, 10, 10, true);
-    SeqFloat32 solidDashes = pixie_new_seq_float32();
+    SeqFloat32 solidDashes;
     assert(rectPath.fillOverlaps(vector2(5, 5), identity, NON_ZERO));
     assert(rectPath.strokeOverlaps(vector2(0, 5), identity, 2, BUTT_CAP, MITER_JOIN, DEFAULT_MITER_LIMIT, solidDashes));
 
@@ -138,8 +138,8 @@ int main() {
     font.setUnderline(true);
     font.setStrikethrough(true);
     font.setNoKerningAdjustments(true);
-    pixie_font_paints_add(font, solid);
-    assert(pixie_font_paints_len(font) >= 1);
+    font.addPaints(solid);
+    assert(font.paintsSize() >= 1);
     assert(font.scale() > 0);
     assert(font.defaultLineHeight() > 0);
     assert(font.layoutBounds("abcd").x > 0);
@@ -147,10 +147,10 @@ int main() {
 
     Span span("hi", font);
     span.setText("hello");
-    SeqSpan spans = pixie_new_seq_span();
-    pixie_seq_span_add(spans, span);
+    SeqSpan spans;
+    spans.add(span);
     Arrangement arrangement = spans.typeset(vector2(100, 100), CENTER_ALIGN, BOTTOM_ALIGN, true);
-    assert(std::strcmp(pixie_seq_span_get(spans, 0).getText(), "hello") == 0);
+    assert(std::strcmp(spans[0].getText(), "hello") == 0);
     assert(arrangement.layoutBounds().x > 0);
     assert(spans.layoutBounds().y > 0);
     assert(arrangement.computeBounds(mat).x > 0);
@@ -188,7 +188,7 @@ int main() {
     assert(ctx.isPointInStroke(rectPath, 0, 5));
     ctx.setLineDash(dashes);
     SeqFloat32 ctxDashes = ctx.getLineDash();
-    assert(pixie_seq_float32_len(ctxDashes) == 2);
+    assert(ctxDashes.size() == 2);
     ctx.moveTo(1, 1);
     ctx.lineTo(2, 2);
     ctx.bezierCurveTo(1, 2, 3, 4, 5, 6);


### PR DESCRIPTION

- Use C++ standard integer spelling in generated C++ headers: `<cstdint>`, `std::int*_t`, `std::uint*_t`, `std::intptr_t`, and `std::uintptr_t`.
- Emit C++ constants as `static constexpr` values and enum aliases as `using ... = std::uint8_t` with typed constexpr entries instead of preprocessor macros.
- Store generated C++ reference handles as `std::uintptr_t` and return `bool` from generated C++ equality ABI declarations.
- Add C++ sequence wrapper constructors and methods: `size`, `get`, `operator[]`, `set`, `removeAt`, `add`, and `clear`.
- Add owner methods for exported sequence fields, such as `addGradientStops`, `gradientStopsSize`, and `getGradientStops`.

